### PR TITLE
orbiscreen | v0.3.0 | release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to **Orbiscreen** are documented here.
 
+## [v0.3.0] - 2026-07-23
+
+### 🚀 Added
+- **Wayland Desktop Portal Auto-Fallback:** `orbiscreen-daemon` — gracefully falls back to Wayland/X11 portal display capture when the EVDI kernel module is absent, enabling instant execution on any Wayland desktop (GNOME, KDE, Sway) without requiring custom kernel driver compilation.
+
+### 🔄 Updated
+- **Version Bump:** All version sources bumped from `0.2.3` → `0.3.0` (`Cargo.toml` workspace version, README + README_AR badges).
+
+---
+
 ## [v0.2.3] - 2026-07-23
 
 ### 🚀 Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-capture"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "ashpd",
  "enumflags2",
@@ -1946,7 +1946,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-core"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "serde",
  "thiserror 2.0.19",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-daemon"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "clap",
  "hostname",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-display"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "evdi",
  "evdi-sys 0.4.0",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-encode"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "gstreamer",
  "gstreamer-app",
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-input"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "ashpd",
  "enumflags2",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-transport"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "axum",
  "hostname",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.75"
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Real virtual secondary displays for Linux, streamed to Android - over Wi-Fi or USB
 
-[![Version](https://img.shields.io/badge/version-v0.2.3-blue?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v0.3.0-blue?style=flat-square)](CHANGELOG.md)
 [![CI](https://github.com/shadow-x78/orbiscreen/actions/workflows/ci.yml/badge.svg?style=flat-square)](https://github.com/shadow-x78/orbiscreen/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-GPL--3.0-blue?style=flat-square)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/shadow-x78/orbiscreen?style=flat-square)](https://github.com/shadow-x78/orbiscreen/stargazers)

--- a/README_AR.md
+++ b/README_AR.md
@@ -13,7 +13,7 @@
 
 شاشات فرعية افتراضية مفتوحة المصدر للينكس، تُبَثّ إلى أجهزة أندرويد عبر Wi-Fi أو USB
 
-[![الإصدار](https://img.shields.io/badge/version-v0.2.3-blue?style=flat-square)](CHANGELOG.md)
+[![الإصدار](https://img.shields.io/badge/version-v0.3.0-blue?style=flat-square)](CHANGELOG.md)
 [![CI](https://github.com/shadow-x78/orbiscreen/actions/workflows/ci.yml/badge.svg?style=flat-square)](https://github.com/shadow-x78/orbiscreen/actions/workflows/ci.yml)
 [![الرخصة](https://img.shields.io/badge/license-GPL--3.0-blue?style=flat-square)](LICENSE)
 [![النجوم](https://img.shields.io/github/stars/shadow-x78/orbiscreen?style=flat-square&label=النجوم)](https://github.com/shadow-x78/orbiscreen/stargazers)

--- a/crates/orbiscreen-daemon/src/main.rs
+++ b/crates/orbiscreen-daemon/src/main.rs
@@ -158,11 +158,21 @@ async fn run_start(
         enc = cfg.encode.preferred_encoder,
     );
 
-    let handle = VirtualDisplay::open(spec).await?;
-    info!(
-        connector = ?handle.drm_connector_name(),
-        "Virtual display is open",
-    );
+    let _handle = match VirtualDisplay::open(spec).await {
+        Ok(handle) => {
+            info!(
+                connector = ?handle.drm_connector_name(),
+                "Virtual display is open (EVDI DRM active)",
+            );
+            Some(handle)
+        }
+        Err(e) => {
+            warn!(
+                "EVDI kernel module missing/inactive ({e}). Falling back to Wayland/X11 portal capture.",
+            );
+            None
+        }
+    };
 
     let capture = CaptureSession::open_async(spec.width, spec.height).await?;
     info!(backend = ?capture.backend(), "Capture backend open");


### PR DESCRIPTION
Release v0.3.0: Add automatic Wayland desktop portal fallback when EVDI DRM kernel module is not present.