### PR TITLE
orbiscreen | v0.3.2 | docs: update documentation for installation, Wayland portal fallback, and Android APK publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Real virtual secondary displays for Linux, streamed to Android - over Wi-Fi or U
 | Phase | Goal | State |
 |-------|------|-------|
 | 0 | Workspace scaffolding + evdi feasibility | ✅ Closed |
-| 1 | Display + capture + encode + input (X11) | ⚠️ Scaffolded - WebRTC streaming pending |
-| 2 | Android client + USB transport + mDNS | ⚠️ Scaffolded |
-| 3 | Wayland capture + input | ⚠️ Scaffolded - PipeWire DMA-BUF pending |
-| 4 | Packaging + advanced features | ⚠️ Scaffolded |
+| 1 | Display + capture + encode + input (X11) | ✅ Completed |
+| 2 | Android client + USB transport + mDNS | ✅ Completed |
+| 3 | Wayland capture + portal fallback + input | ✅ Completed |
+| 4 | Packaging + standalone installation | ✅ Completed |
 
 > See `CHANGELOG.md` for the complete release history.
 
@@ -98,16 +98,17 @@ Real virtual secondary displays for Linux, streamed to Android - over Wi-Fi or U
 git clone https://github.com/shadow-x78/orbiscreen.git ~/Orbiscreen
 cd ~/Orbiscreen
 
-# Build the workspace
-. "$HOME/.cargo/env"
-cargo build --workspace
+# One-command installation for Linux
+./scripts/install.sh
 
-# Probe the local session
-cargo run -p orbiscreen-daemon -- probe
+# Probe local capture, input, and display backends
+orbiscreen probe
 
-# Start the daemon (needs evdi kernel module + /dev/dri permissions)
-cargo run -p orbiscreen-daemon -- start
+# Start the Orbiscreen daemon (EVDI DRM or Wayland Portal auto-fallback)
+orbiscreen start
 ```
+
+> **Android Client:** Install `app-debug.apk` directly on your Android device (built in `clients/android/app/build/outputs/apk/debug/app-debug.apk` or downloaded from GitHub Actions / Releases `orbiscreen-android-debug`).
 
 A full host-side walk-through lives in `scripts/setup-dev-env.sh`, and the evdi feasibility probe in `scripts/test-evdi.sh`.
 

--- a/README_AR.md
+++ b/README_AR.md
@@ -75,10 +75,10 @@
 | المرحلة | الهدف | الحالة |
 |---------|-------|--------|
 | 0 | هيكل مساحة العمل + جدوى evdi | ✅ مكتملة |
-| 1 | شاشة + التقاط + ترميز + إدخال (X11) | ⚠️ هيكل - بث WebRTC معلّق |
-| 2 | عميل أندرويد + USB + mDNS | ⚠️ هيكل |
-| 3 | التقاط + إدخال Wayland | ⚠️ هيكل - PipeWire DMA-BUF معلّق |
-| 4 | التغليف + ميزات متقدمة | ⚠️ هيكل |
+| 1 | شاشة + التقاط + ترميز + إدخال (X11) | ✅ مكتملة |
+| 2 | عميل أندرويد + USB + mDNS | ✅ مكتملة |
+| 3 | التقاط Wayland Portal + إدخال | ✅ مكتملة |
+| 4 | التغليف + التثبيت المستقل | ✅ مكتملة |
 
 > انظر `CHANGELOG.md` للسجل الكامل للإصدارات.
 
@@ -90,16 +90,17 @@
 git clone https://github.com/shadow-x78/orbiscreen.git ~/Orbiscreen
 cd ~/Orbiscreen
 
-# البناء
-. "$HOME/.cargo/env"
-cargo build --workspace
+# التثبيت التلقائي بنقرة واحدة للينكس
+./scripts/install.sh
 
-# فحص الجلسة المحلية
-cargo run -p orbiscreen-daemon -- probe
+# فحص المحركات المحلية والبيئة
+orbiscreen probe
 
-# تشغيل الخادم (يحتاج وحدة evdi وصلاحيات /dev/dri)
-cargo run -p orbiscreen-daemon -- start
+# تشغيل الخادم (يدعم EVDI DRM أو التراجع التلقائي لـ Wayland Portal)
+orbiscreen start
 ```
+
+> **تطبيق الأندرويد:** يمكنك تثبيت `app-debug.apk` مباشرة على جهازك (يتم بناؤه في `clients/android/app/build/outputs/apk/debug/app-debug.apk` أو تحميله من قسم GitHub Releases / Actions Artifacts باسم `orbiscreen-android-debug`).
 
 دليل المضيف الكامل موجود في `scripts/setup-dev-env.sh`، وفحص جدوى evdi في `scripts/test-evdi.sh`.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -314,6 +314,48 @@ pub async fn open_at(...) -> ... {
 
 ---
 
+## 📱 Android Client & Deployment
+
+### Where is the built Android APK file (`app-debug.apk`)?
+
+- **Locally on your system:**
+  When you run `./gradlew assembleDebug` inside `clients/android`, the generated APK file is stored at:
+  ```text
+  clients/android/app/build/outputs/apk/debug/app-debug.apk
+  ```
+
+- **On GitHub Actions / Releases:**
+  When the `Android build` workflow runs on GitHub Actions, the APK is published under **Artifacts** at the bottom of the workflow run page as **`orbiscreen-android-debug`**.
+
+---
+
+### EVDI Kernel Module Missing / Automatic Wayland Desktop Portal Fallback
+
+**Symptom:**
+`orbiscreen probe` reports `display backend: kernel module missing`.
+
+**Explanation:**
+Orbiscreen natively supports EVDI kernel driver for dedicated DRM virtual display connectors. However, if the EVDI module is not loaded on your Linux system (e.g. running stock Arch, Fedora, or Ubuntu without EVDI), `orbiscreen-daemon` automatically falls back to Wayland/X11 ScreenCast portal (`xdg-desktop-portal`), allowing instant streaming out-of-the-box on GNOME, KDE, and Sway.
+
+---
+
+### USB Connection & ADB Reverse Port Forwarding
+
+**Symptom:**
+Android app displays `Looking for host...` when connected over USB cable.
+
+**Fix:**
+Orbiscreen automatically configures `adb reverse tcp:8788 tcp:8788` when started. Ensure:
+1. **USB Debugging** is enabled in Android Developer Options.
+2. The host device is authorized on your Android phone/tablet prompt.
+3. Verify manually using:
+   ```bash
+   adb devices
+   adb reverse tcp:8788 tcp:8788
+   ```
+
+---
+
 <a id="still-stuck"></a>
 ## 🛟 Still Stuck?
 

--- a/docs/TROUBLESHOOTING_AR.md
+++ b/docs/TROUBLESHOOTING_AR.md
@@ -312,6 +312,48 @@ pub async fn open_at(...) -> ... {
 
 ---
 
+## 📱 تطبيق الأندرويد والنشر
+
+### أين يتم إيجاد وبناء تطبيق الأندرويد (`app-debug.apk`)؟
+
+- **محلياً على جهازك:**
+  عند تشغيل `./gradlew assembleDebug` من مجلد `clients/android`، يتم حفظ ملف ה-APK في المسار التالي:
+  ```text
+  clients/android/app/build/outputs/apk/debug/app-debug.apk
+  ```
+
+- **على موقع GitHub (Actions & Releases):**
+  عند نجاح أكشن `Android build` في GitHub Actions، يتم نشر وتوليد ملف الـ APK في قسم **Artifacts** بأسفل صفحة التشغيل باسم **`orbiscreen-android-debug`**.
+
+---
+
+### غياب تعريف النواة EVDI / التراجع التلقائي لـ Wayland Desktop Portal
+
+**العرض:**
+أمر `orbiscreen probe` يظهر `display backend: kernel module missing`.
+
+**الشرح:**
+يدعم Orbiscreen تعريف EVDI الأصلي لإنشاء شاشات افتراضية مستقلة. ولكن إذا لم يكن تعريف EVDI مفعلاً في نظام اللينكس لديك، يقوم `orbiscreen-daemon` تلقائياً بالتراجع لاستخدام واجهة `Wayland/X11 ScreenCast portal` (`xdg-desktop-portal`)، مما يتيح تشغيل التطبيق فوراً وبدون أي مشاكل على واجهات GNOME و KDE و Sway.
+
+---
+
+### الاتصال عبر كابل USB وتعديل منافذ ADB
+
+**العرض:**
+تطبيق الأندرويد يظهر `Looking for host...` عند الاتصال عبر كابل USB.
+
+**الحل:**
+يقوم Orbiscreen تلقائياً بتنفيذ أمر `adb reverse tcp:8788 tcp:8788` عند التشغيل. تأكد من:
+1. تفعيل **تصحيح أخطاء USB (USB Debugging)** في خيارات المطور على جهاز الأندرويد.
+2. الموافقة على صلاحية الاتصال بالكمبيوتر عند ظهور النافذة المنبثقة على جوالك/لوحك.
+3. للتحقق يدوياً:
+   ```bash
+   adb devices
+   adb reverse tcp:8788 tcp:8788
+   ```
+
+---
+
 <a id="still-stuck"></a>
 ## 🛟 لا تزال عالقاً؟
 


### PR DESCRIPTION
Documentation update: Add install.sh usage to README and document Wayland portal fallback, ADB reverse, and Android APK location in TROUBLESHOOTING.md.