### PR TITLE
orbiscreen | v0.4.3 | release: v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to **Orbiscreen** are documented here.
 
+## [v0.4.3] - 2026-07-23
+
+### 🚀 Added
+- **World-Class System Architecture Specifications:** `docs/ARCHITECTURE.md` & `docs/ARCHITECTURE_AR.md` — published bilingual system topology specifications, workspace crate breakdown, and zero-copy streaming pipeline diagrams.
+- **Bilingual Documentation Pairing:** Added English/Arabic `_AR` bilingual documentation pairs for all documentation (`SECURITY_AR.md`, `DBUS_SPEC_AR.md`, `PACKAGING_AR.md`, `ARCHITECTURE_AR.md`).
+
+### 🔄 Updated
+- **Version Bump:** All version sources bumped from `0.4.2` → `0.4.3` (`Cargo.toml` workspace version, README + README_AR badges).
+
+---
+
 ## [v0.4.2] - 2026-07-23
 
 ### 🚀 Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-capture"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "ashpd",
  "enumflags2",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "serde",
  "thiserror 2.0.19",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-daemon"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "clap",
  "hostname",
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-display"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "evdi",
  "evdi-sys 0.4.0",
@@ -2413,7 +2413,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-encode"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "gstreamer",
  "gstreamer-app",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-gtk"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "gtk4",
  "libadwaita",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-input"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "ashpd",
  "enumflags2",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-transport"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "axum",
  "hostname",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 rust-version = "1.75"
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Real virtual secondary displays for Linux, streamed to Android - over Wi-Fi or USB
 
-[![Version](https://img.shields.io/badge/version-v0.4.2-blue?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v0.4.3-blue?style=flat-square)](CHANGELOG.md)
 [![CI](https://github.com/shadow-x78/orbiscreen/actions/workflows/ci.yml/badge.svg?style=flat-square)](https://github.com/shadow-x78/orbiscreen/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-GPL--3.0-blue?style=flat-square)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/shadow-x78/orbiscreen?style=flat-square)](https://github.com/shadow-x78/orbiscreen/stargazers)

--- a/README_AR.md
+++ b/README_AR.md
@@ -13,7 +13,7 @@
 
 شاشات فرعية افتراضية مفتوحة المصدر للينكس، تُبَثّ إلى أجهزة أندرويد عبر Wi-Fi أو USB
 
-[![الإصدار](https://img.shields.io/badge/version-v0.4.2-blue?style=flat-square)](CHANGELOG.md)
+[![الإصدار](https://img.shields.io/badge/version-v0.4.3-blue?style=flat-square)](CHANGELOG.md)
 [![CI](https://github.com/shadow-x78/orbiscreen/actions/workflows/ci.yml/badge.svg?style=flat-square)](https://github.com/shadow-x78/orbiscreen/actions/workflows/ci.yml)
 [![الرخصة](https://img.shields.io/badge/license-GPL--3.0-blue?style=flat-square)](LICENSE)
 [![النجوم](https://img.shields.io/github/stars/shadow-x78/orbiscreen?style=flat-square&label=النجوم)](https://github.com/shadow-x78/orbiscreen/stargazers)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,85 @@
+# Architecture Specification - Orbiscreen
+
+---
+
+## 🌐 Language
+
+<a href="ARCHITECTURE.md">🇬🇧 English</a> · <a href="ARCHITECTURE_AR.md">🇸🇦 العربية</a>
+
+---
+
+## 🏛 System Architecture Overview
+
+Orbiscreen is built as a modular multi-crate Rust workspace separating system display drivers, frame capture engines, hardware-accelerated video encoders, inter-process communication (D-Bus), and multi-protocol network transports.
+
+```mermaid
+graph TD
+    subgraph Control_Layer [Control & Management]
+        GTK["GTK4 / Libadwaita GUI (orbiscreen-gtk)"]
+        TRAY["System Tray Indicator"]
+        CLI["CLI Interface (orbiscreen)"]
+        DBUS["D-Bus Session Bus (com.orbiscreen.Daemon)"]
+    end
+
+    subgraph Service_Layer [Daemon Core Engine]
+        DAEMON["Orbiscreen Daemon (orbiscreen-daemon)"]
+        CORE["Core Engine & Config (orbiscreen-core)"]
+    end
+
+    subgraph Display_Capture_Layer [Display & Capture]
+        DRM["EVDI DRM Virtual Display (orbiscreen-display)"]
+        PORTAL["Wayland ScreenCast Portal (orbiscreen-capture)"]
+        X11_CAP["X11 Capture Engine (orbiscreen-capture)"]
+    end
+
+    subgraph Encode_Transport_Layer [Encode & Stream Transport]
+        GSTREAMER["H.264 Encoder (orbiscreen-encode)"]
+        TRANSPORT["Axum HTTP / WebRTC Transport (orbiscreen-transport)"]
+        MDNS["mDNS SD Service Discovery (mdns-sd)"]
+    end
+
+    subgraph Input_Layer [Reverse Touch & Input]
+        UINPUT["Linux uinput Virtual Touchscreen (orbiscreen-input)"]
+    end
+
+    GTK <-->|D-Bus Session IPC| DBUS
+    TRAY <-->|D-Bus Session IPC| DBUS
+    CLI <-->|D-Bus Session IPC| DBUS
+    DBUS <--> DAEMON
+
+    DAEMON --> CORE
+    DAEMON --> DRM
+    DAEMON --> PORTAL
+    DAEMON --> GSTREAMER
+    DAEMON --> TRANSPORT
+    DAEMON --> UINPUT
+
+    TRANSPORT <-->|HTTP /stream & WebRTC| Clients[Android App & HTML5 Web Client]
+    Clients -->|Reverse Touch / Stylus / Key Events| TRANSPORT
+    TRANSPORT --> UINPUT
+```
+
+---
+
+## 📦 Workspace Crate Topology
+
+| Crate | Responsibility | Key Dependencies |
+|-------|----------------|------------------|
+| `orbiscreen-core` | Shared configuration, error types, serialization | `serde`, `toml` |
+| `orbiscreen-display` | EVDI DRM virtual display creation & EDID synthesis | `evdi`, `libc` |
+| `orbiscreen-capture` | Wayland Portal (ashpd) & X11 (x11rb) capture engines | `ashpd`, `x11rb` |
+| `orbiscreen-encode` | Hardware & software H.264 encoding pipelines | `gstreamer`, `gstreamer-app` |
+| `orbiscreen-input` | Reverse touch, stylus, and keyboard injection | `evdevil`, `nix` |
+| `orbiscreen-transport` | Axum HTTP `/stream`, WebRTC signaling & ADB reverse | `axum`, `webrtc`, `tokio` |
+| `orbiscreen-daemon` | Main daemon binary, systemd integration & D-Bus service | `zbus`, `clap`, `tokio` |
+| `orbiscreen-gtk` | Native GTK4 / Libadwaita desktop GUI control panel | `gtk4`, `libadwaita`, `zbus` |
+
+---
+
+## ⚡ Zero-Copy Stream Pipeline
+
+1. **Virtual Monitor Provisioning:** `orbiscreen-display` provisions a virtual DRM connector via EVDI (or falls back to `xdg-desktop-portal` ScreenCast session).
+2. **Frame Capture:** Raw BGRA frame buffers are grabbed via PipeWire DMA-BUF / X11 Shared Memory.
+3. **Hardware Encoding:** GStreamer encodes frames into H.264 Annex B NAL units (`orbiscreen-encode`).
+4. **Multi-Protocol Broadcast:** Encoded chunks are broadcast simultaneously over `/stream` HTTP GET (Axum) and WebRTC RTP video tracks.
+5. **Reverse Touch Injection:** Input events sent by Android client or Web UI are mapped through `TouchCalibration` and injected directly into Linux kernel `/dev/uinput`.

--- a/docs/ARCHITECTURE_AR.md
+++ b/docs/ARCHITECTURE_AR.md
@@ -1,0 +1,75 @@
+# مواصفات معمارية النظام - Orbiscreen
+
+---
+
+## 🌐 اللغة
+
+<a href="ARCHITECTURE.md">🇬🇧 English</a> · <a href="ARCHITECTURE_AR.md">🇸🇦 العربية</a>
+
+---
+
+## 🏛 الهيكل المعماري للنظام
+
+بُني مشروع **Orbiscreen** كمنظومة برمجية قياسية مقسمة على عدة حزم (Rust Workspace) لفصل محركات الشاشات، والالتقاط، والترميز، والتواصل عبر D-Bus، وبروتوكولات النقل الشبكي:
+
+```mermaid
+graph TD
+    subgraph Control_Layer [طبقة التحكم والإدارة]
+        GTK["واجهة GTK4 / Libadwaita (orbiscreen-gtk)"]
+        TRAY["أيقونة شريط النظام (System Tray)"]
+        CLI["واجهة السطر الأوامر (orbiscreen)"]
+        DBUS["ناقل D-Bus Session Bus (com.orbiscreen.Daemon)"]
+    end
+
+    subgraph Service_Layer [المحرك الأساسي والخادم]
+        DAEMON["الخادم الأساسي (orbiscreen-daemon)"]
+        CORE["المحرك والإعدادات (orbiscreen-core)"]
+    end
+
+    subgraph Display_Capture_Layer [طبقة العرض والالتقاط]
+        DRM["الشاشة الافتراضية EVDI DRM (orbiscreen-display)"]
+        PORTAL["التقاط Wayland ScreenCast Portal (orbiscreen-capture)"]
+        X11_CAP["التقاط X11 (orbiscreen-capture)"]
+    end
+
+    subgraph Encode_Transport_Layer [طبقة الترميز والبث]
+        GSTREAMER["مرمز H.264 (orbiscreen-encode)"]
+        TRANSPORT["شبكة النقل Axum HTTP / WebRTC (orbiscreen-transport)"]
+        MDNS["اكتشاف الأجهزة mDNS SD (mdns-sd)"]
+    end
+
+    subgraph Input_Layer [طبقة حقن اللمس والإدخال]
+        UINPUT["محاقن اللمس والقلم uinput (orbiscreen-input)"]
+    end
+
+    GTK <-->|D-Bus Session IPC| DBUS
+    TRAY <-->|D-Bus Session IPC| DBUS
+    CLI <-->|D-Bus Session IPC| DBUS
+    DBUS <--> DAEMON
+
+    DAEMON --> CORE
+    DAEMON --> DRM
+    DAEMON --> PORTAL
+    DAEMON --> GSTREAMER
+    DAEMON --> TRANSPORT
+    DAEMON --> UINPUT
+
+    TRANSPORT <-->|HTTP /stream & WebRTC| Clients[تطبيق الأندرويد ومشغل الويب]
+    Clients -->|أحداث اللمس والقلم ولوحة المفاتيح| TRANSPORT
+    TRANSPORT --> UINPUT
+```
+
+---
+
+## 📦 توزيع الحزم ومسؤولياتها
+
+| الحزمة | المسؤولية | المكتبات الرئيسية |
+|-------|----------------|------------------|
+| `orbiscreen-core` | الإعدادات المشتركة، أنواع الأخطاء، الترميز | `serde`, `toml` |
+| `orbiscreen-display` | إنشاء الشاشات الافتراضية EVDI وتوليد EDID | `evdi`, `libc` |
+| `orbiscreen-capture` | التقاط الشاشة عبر Wayland Portal و X11 | `ashpd`, `x11rb` |
+| `orbiscreen-encode` | خطوط ترميز الفيديو H.264 بالعتاد والبرمجيات | `gstreamer`, `gstreamer-app` |
+| `orbiscreen-input` | حقن أحداث اللمس والقلم ولوحة المفاتيح في النواة | `evdevil`, `nix` |
+| `orbiscreen-transport` | بث `/stream` عبر Axum و WebRTC و ADB reverse | `axum`, `webrtc`, `tokio` |
+| `orbiscreen-daemon` | الملف التنفيذي للخدمة وتوفير واجهة D-Bus | `zbus`, `clap`, `tokio` |
+| `orbiscreen-gtk` | لوحة التحكم الرسومية بسطح المكتب GTK4 / Libadwaita | `gtk4`, `libadwaita`, `zbus` |


### PR DESCRIPTION
Release v0.4.3: World-class architecture specifications, zero-copy stream pipeline documentation, and complete bilingual English/Arabic docs.