### PR TITLE
orbiscreen | docs: remove leftover Language sections from all docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,6 @@
 # Security Policy - Orbiscreen
 
----
 
-## 🌐 Language
-
-<a href="SECURITY.md">🇬🇧 English</a> · <a href="SECURITY_AR.md">🇸🇦 العربية</a>
-
----
 
 ## 📋 Table of Contents
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,12 +1,6 @@
 # Architecture Specification - Orbiscreen
 
----
 
-## 🌐 Language
-
-<a href="ARCHITECTURE.md">🇬🇧 English</a> · <a href="ARCHITECTURE_AR.md">🇸🇦 العربية</a>
-
----
 
 ## 🏛 System Architecture Overview
 

--- a/docs/DBUS_SPEC.md
+++ b/docs/DBUS_SPEC.md
@@ -1,12 +1,6 @@
 # D-Bus API Specification - Orbiscreen
 
----
 
-## 🌐 Language
-
-<a href="DBUS_SPEC.md">🇬🇧 English</a> · <a href="DBUS_SPEC_AR.md">🇸🇦 العربية</a>
-
----
 
 ## 🛰 Overview
 

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -1,12 +1,6 @@
 # Multi-Distro Packaging Guide - Orbiscreen
 
----
 
-## 🌐 Language
-
-<a href="PACKAGING.md">🇬🇧 English</a> · <a href="PACKAGING_AR.md">🇸🇦 العربية</a>
-
----
 
 ## 📦 Overview
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,12 +1,6 @@
 # Troubleshooting - Orbiscreen
 
----
 
-## 🌐 Language
-
-<a href="TROUBLESHOOTING.md">🇬🇧 English</a> · <a href="TROUBLESHOOTING_AR.md">🇸🇦 العربية</a>
-
----
 
 ## 📋 Table of Contents
 


### PR DESCRIPTION
Remove leftover Language navigation blocks from SECURITY.md and all docs/* files.