### PR TITLE
orbiscreen | v0.8.1 | fix: return 503 from sdp_post

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.75"
 license = "GPL-3.0-or-later"

--- a/clients/android/app/build.gradle.kts
+++ b/clients/android/app/build.gradle.kts
@@ -18,7 +18,7 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = 5
-        versionName = "0.8.0"
+        versionName = "0.8.1"
     }
 
     signingConfigs {

--- a/crates/orbiscreen-transport/src/lib.rs
+++ b/crates/orbiscreen-transport/src/lib.rs
@@ -177,14 +177,12 @@ struct SdpPayload {
 
 async fn sdp_post(
     State(_state): State<AppState>,
-    Json(payload): Json<SdpPayload>,
+    Json(_payload): Json<SdpPayload>,
 ) -> impl IntoResponse {
-    info!("Received SDP offer: length {}", payload.sdp.len());
     (
-        StatusCode::OK,
+        StatusCode::SERVICE_UNAVAILABLE,
         Json(serde_json::json!({
-            "type": "answer",
-            "sdp": payload.sdp,
+            "error": "WebRTC not yet implemented, use /stream"
         })),
     )
 }


### PR DESCRIPTION
Phase 2 of architecture overhaul. Fixes fake WebRTC signaling.