### PR TITLE
orbiscreen | v0.8.7 | docs: update architecture docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.6"
+version = "0.8.7"
 edition = "2021"
 rust-version = "1.75"
 license = "GPL-3.0-or-later"
@@ -41,7 +41,6 @@ gstreamer = "0.25"
 gstreamer-app = "0.25"
 gstreamer-video = "0.25"
 
-webrtc = "0.20.0-rc.3"
 mdns-sd = "0.20"
 axum = { version = "0.8", features = ["ws"] }
 tower-http = { version = "0.6", features = ["fs"] }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <p>Real virtual secondary displays for Linux, streamed to Android - over Wi-Fi or USB</p>
 
   <p>
-    <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-v0.7.3-blue?style=flat-square" alt="Version" /></a>
+    <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-v0.8.7-blue?style=flat-square" alt="Version" /></a>
     <a href="https://github.com/shadow-x78/orbiscreen/actions/workflows/ci.yml"><img src="https://github.com/shadow-x78/orbiscreen/actions/workflows/ci.yml/badge.svg?style=flat-square" alt="CI" /></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPL--3.0-blue?style=flat-square" alt="License" /></a>
     <a href="https://github.com/shadow-x78/orbiscreen/stargazers"><img src="https://img.shields.io/github/stars/shadow-x78/orbiscreen?style=flat-square" alt="Stars" /></a>
@@ -29,7 +29,7 @@
 <a id="what-is-orbiscreen"></a>
 ## 🤔 What is Orbiscreen?
 
-**Orbiscreen** turns a spare Android tablet or phone into a real second monitor for your Linux desktop. Unlike X11-only or browser-only workarounds, Orbiscreen creates a **kernel-level virtual display** via DisplayLink's `evdi`, which appears as a genuine monitor to both X11 and Wayland compositors, and streams it over **WebRTC** with reverse touch input.
+**Orbiscreen** turns a spare Android tablet or phone into a real second monitor for your Linux desktop. Unlike X11-only or browser-only workarounds, Orbiscreen creates a **kernel-level virtual display** via DisplayLink's `evdi`, which appears as a genuine monitor to both X11 and Wayland compositors, and streams it using **MPEG-TS/H.264** with reverse touch input natively on Android.
 
 ---
 
@@ -49,7 +49,7 @@
 ## ✨ Highlights
 
 - Real virtual display via `evdi` (X11 *and* Wayland)
-- WebRTC streaming - opens in any modern browser, no app install needed
+- Native Android App - uses ExoPlayer & MediaCodec for ultra-low latency hardware decoding
 - Reverse touch - pointer / keyboard / stylus events flow Android → host
 - mDNS discovery - Android clients find the host automatically
 - USB transport via `adb reverse`, no special drivers

--- a/clients/android/app/build.gradle.kts
+++ b/clients/android/app/build.gradle.kts
@@ -18,7 +18,7 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = 5
-        versionName = "0.8.6"
+        versionName = "0.8.7"
     }
 
     signingConfigs {

--- a/crates/orbiscreen-transport/Cargo.toml
+++ b/crates/orbiscreen-transport/Cargo.toml
@@ -13,7 +13,7 @@ description = "WebRTC streaming, signaling, and mDNS host discovery"
 workspace = true
 
 [dependencies]
-webrtc = { workspace = true }
+
 mdns-sd = { workspace = true }
 axum = { workspace = true }
 tokio = { workspace = true }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,49 +8,24 @@ Orbiscreen is built as a modular multi-crate Rust workspace separating system di
 
 ```mermaid
 graph TD
-    subgraph Control_Layer [Control & Management]
-        GTK["GTK4 / Libadwaita GUI (orbiscreen-gtk)"]
-        TRAY["System Tray Indicator"]
-        CLI["CLI Interface (orbiscreen)"]
-        DBUS["D-Bus Session Bus (com.orbiscreen.Daemon)"]
+    subgraph Host Linux Machine
+        A[evdi Kernel Module] -->|Virtual DRM Device| B(Display Server X11/Wayland)
+        B -->|Screen Content| C(orbiscreen-capture)
+        C -->|Raw BGRA Frames| D(orbiscreen-encode)
+        D -->|GStreamer HW Encode| E(H.264 Stream)
+        E --> F(orbiscreen-transport)
+        F -->|MPEG-TS HTTP Stream| G((Network/USB))
+        F -->|mDNS Broadcast| G
     end
 
-    subgraph Service_Layer [Daemon Core Engine]
-        DAEMON["Orbiscreen Daemon (orbiscreen-daemon)"]
-        CORE["Core Engine & Config (orbiscreen-core)"]
+    subgraph Android Device
+        G -->|Auto-discover host| H(Android NsdManager)
+        G -->|MPEG-TS Stream| I(AndroidX Media3 ExoPlayer)
+        I -->|Hardware Decoding| J[MediaCodec]
+        J --> K[SurfaceView]
+        K -.->|Touch Events| L(TouchInjector)
+        L -.->|HTTP JSON POST| F
     end
-
-    subgraph Display_Capture_Layer [Display & Capture]
-        DRM["EVDI DRM Virtual Display (orbiscreen-display)"]
-        PORTAL["Wayland ScreenCast Portal (orbiscreen-capture)"]
-        X11_CAP["X11 Capture Engine (orbiscreen-capture)"]
-    end
-
-    subgraph Encode_Transport_Layer [Encode & Stream Transport]
-        GSTREAMER["H.264 Encoder (orbiscreen-encode)"]
-        TRANSPORT["Axum HTTP / WebRTC Transport (orbiscreen-transport)"]
-        MDNS["mDNS SD Service Discovery (mdns-sd)"]
-    end
-
-    subgraph Input_Layer [Reverse Touch & Input]
-        UINPUT["Linux uinput Virtual Touchscreen (orbiscreen-input)"]
-    end
-
-    GTK <-->|D-Bus Session IPC| DBUS
-    TRAY <-->|D-Bus Session IPC| DBUS
-    CLI <-->|D-Bus Session IPC| DBUS
-    DBUS <--> DAEMON
-
-    DAEMON --> CORE
-    DAEMON --> DRM
-    DAEMON --> PORTAL
-    DAEMON --> GSTREAMER
-    DAEMON --> TRANSPORT
-    DAEMON --> UINPUT
-
-    TRANSPORT <-->|HTTP /stream & WebRTC| Clients[Android App & HTML5 Web Client]
-    Clients -->|Reverse Touch / Stylus / Key Events| TRANSPORT
-    TRANSPORT --> UINPUT
 ```
 
 ---
@@ -64,7 +39,7 @@ graph TD
 | `orbiscreen-capture` | Wayland Portal (ashpd) & X11 (x11rb) capture engines | `ashpd`, `x11rb` |
 | `orbiscreen-encode` | Hardware & software H.264 encoding pipelines | `gstreamer`, `gstreamer-app` |
 | `orbiscreen-input` | Reverse touch, stylus, and keyboard injection | `evdevil`, `nix` |
-| `orbiscreen-transport` | Axum HTTP `/stream`, WebRTC signaling & ADB reverse | `axum`, `webrtc`, `tokio` |
+| `orbiscreen-transport` | Axum HTTP MPEG-TS `/stream` & ADB reverse | `axum`, `gstreamer`, `tokio` |
 | `orbiscreen-daemon` | Main daemon binary, systemd integration & D-Bus service | `zbus`, `clap`, `tokio` |
 | `orbiscreen-gtk` | Native GTK4 / Libadwaita desktop GUI control panel | `gtk4`, `libadwaita`, `zbus` |
 
@@ -74,9 +49,10 @@ graph TD
 
 1. **Virtual Monitor Provisioning:** `orbiscreen-display` provisions a virtual DRM connector via EVDI (or falls back to `xdg-desktop-portal` ScreenCast session).
 2. **Frame Capture:** Raw BGRA frame buffers are grabbed via PipeWire DMA-BUF / X11 Shared Memory.
-3. **Hardware Encoding:** GStreamer encodes frames into H.264 Annex B NAL units (`orbiscreen-encode`).
-4. **Multi-Protocol Broadcast:** Encoded chunks are broadcast simultaneously over `/stream` HTTP GET (Axum) and WebRTC RTP video tracks.
-5. **Reverse Touch Injection:** Input events sent by Android client or Web UI are mapped through `TouchCalibration` and injected directly into Linux kernel `/dev/uinput`.
+3. **Hardware Encoding:** 
+- **orbiscreen-encode**: Consumes the raw X11/PipeWire frame buffers and encodes them into H.264 using hardware-accelerated GStreamer pipelines (VAAPI, NVENC, or fallback x264).
+- **orbiscreen-transport**: Wraps the encoded H.264 NAL units into an MPEG-TS container and serves them over an HTTP stream. Also handles reverse touch injection and mDNS broadcasting.
+- **Android Client**: A native Android application that automatically discovers the daemon via mDNS, fetches the MPEG-TS stream, and decodes it using AndroidX Media3 (ExoPlayer) which hooks directly into the device's hardware `MediaCodec` for zero-latency playback. It also intercepts touch events on the `SurfaceView` and translates them into relative pointer motions for the daemon.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -103,9 +103,9 @@ Run `cargo clippy` locally before pushing.
 
 **Symptom:**
 ```
-error[E0463]: can't find crate for `webrtc`
+error[E0463]: can't find crate for `gstreamer`
   |
-  = note: the crate `webrtc` couldn't be found in the registry index
+  = note: the crate `gstreamer` couldn't be found in the registry index
 ```
 
 **Cause:**
@@ -116,17 +116,17 @@ runner. With `--locked` enabled, cargo refuses to update the lockfile.
 **Fix:**
 ```bash
 # Locally: regenerate the lockfile
-cargo update -p webrtc
+cargo update -p gstreamer
 # Then rebuild
 cargo build --workspace --locked
 git add Cargo.lock
-git commit -m "orbiscreen | v0.1.1 | chore: refresh Cargo.lock for webrtc 0.20.0-rc.3"
+git commit -m "orbiscreen | v0.8.7 | chore: refresh Cargo.lock for gstreamer 0.23.0"
 ```
 
-If the dependency is `webrtc = "0.20.0-rc.3"` and has been removed or
+If the dependency is `gstreamer = "0.23.0"` and has been removed or
 replaced on `crates.io`, you must either:
-- Pin a different version (`cargo search webrtc`)
-- Wait for a stable release (the workspace pins a release-candidate)
+- Pin a different version (`cargo search gstreamer`)
+- Wait for a stable release
 
 **Prevention:**
 Keep `Cargo.lock` committed (already done) and run `cargo update` only


### PR DESCRIPTION
Phase 8 of architecture overhaul. Updates documentation for MPEG-TS and native Android app, and cleans up old webrtc dependencies.