### PR TITLE
orbiscreen | v0.8.7 | fix: update gstreamer parse_launch

### DIFF
--- a/crates/orbiscreen-capture/src/wayland.rs
+++ b/crates/orbiscreen-capture/src/wayland.rs
@@ -10,7 +10,7 @@ use ashpd::desktop::screencast::{
 use ashpd::desktop::Session;
 use enumflags2::BitFlags;
 use thiserror::Error;
-use tracing::{instrument, trace};
+use tracing::instrument;
 
 use super::{CaptureError, CapturedFrame};
 
@@ -124,7 +124,7 @@ impl WaylandCapture {
             "pipewiresrc fd={} path={} ! videoconvert ! video/x-raw,format=BGRA ! appsink name=sink drop=true max-buffers=1",
             stream.fd, stream.node_id
         );
-        let pipeline = gstreamer::parse_launch(&pipeline_str)?
+        let pipeline = gstreamer::parse::launch(&pipeline_str)?
             .downcast::<gstreamer::Pipeline>()
             .map_err(|_| WaylandCaptureError::Dbus("Failed to downcast pipeline".into()))?;
 

--- a/crates/orbiscreen-transport/src/lib.rs
+++ b/crates/orbiscreen-transport/src/lib.rs
@@ -213,7 +213,7 @@ async fn stream_handler(State(state): State<AppState>) -> impl IntoResponse {
     gstreamer::init().ok();
 
     let pipeline_str = "appsrc name=src format=time ! h264parse ! mpegtsmux alignment=7 ! appsink name=sink drop=false";
-    let pipeline = gstreamer::parse_launch(pipeline_str)
+    let pipeline = gstreamer::parse::launch(pipeline_str)
         .expect("failed to parse mpegtsmux pipeline")
         .downcast::<gstreamer::Pipeline>()
         .unwrap();


### PR DESCRIPTION
Fixes compilation error due to gstreamer API change (parse_launch moved to parse::launch).