### PR TITLE
orbiscreen | v0.8.7 | fix: cargo clippy warnings

### DIFF
--- a/crates/orbiscreen-capture/src/wayland.rs
+++ b/crates/orbiscreen-capture/src/wayland.rs
@@ -166,7 +166,9 @@ impl WaylandCapture {
                 .build(),
         );
 
-        pipeline.set_state(gstreamer::State::Playing)?;
+        pipeline
+            .set_state(gstreamer::State::Playing)
+            .map_err(|e| WaylandCaptureError::Dbus(format!("State error: {}", e)))?;
 
         Ok(Self {
             _screencast: screencast,

--- a/crates/orbiscreen-transport/src/lib.rs
+++ b/crates/orbiscreen-transport/src/lib.rs
@@ -167,17 +167,8 @@ async fn handle_socket(mut socket: axum::extract::ws::WebSocket) {
     }
 }
 
-#[derive(serde::Deserialize)]
-struct SdpPayload {
-    sdp: String,
-    #[allow(dead_code)]
-    #[serde(rename = "type")]
-    sdp_type: Option<String>,
-}
-
 async fn sdp_post(
     State(_state): State<AppState>,
-    Json(_payload): Json<SdpPayload>,
 ) -> impl IntoResponse {
     (
         StatusCode::SERVICE_UNAVAILABLE,


### PR DESCRIPTION
Fixes unused struct warning in transport and StateChangeError trait error in capture.