### PR TITLE
orbiscreen | v0.8.7 | docs: fix RPM gpgcheck warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Download pre-built packages from [GitHub Releases](https://github.com/shadow-x78
 
 - **Fedora / RHEL (`.rpm`):**
   ```bash
-  sudo dnf install ./orbiscreen_x86_64.rpm
+  sudo dnf install --nogpgcheck ./orbiscreen_x86_64.rpm
   ```
 
 - **Universal AppImage (`.AppImage`):**

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -20,7 +20,7 @@ sudo apt-get remove orbiscreen
 
 Download `orbiscreen_x86_64.rpm` from the releases page.
 ```bash
-sudo dnf install ./orbiscreen_x86_64.rpm
+sudo dnf install --nogpgcheck ./orbiscreen_x86_64.rpm
 ```
 
 **Uninstall:**


### PR DESCRIPTION
Adds --nogpgcheck to dnf install commands to prevent warnings when installing local unsigned RPMs.