### PR TITLE
orbiscreen | v0.8.8 | release: universal artifact signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,19 @@ jobs:
           tar -czvf orbiscreen-linux-x86_64.tar.gz -C release-bundle .
 
       - name: Package Debian DEB package
+        env:
+          RPM_GPG_KEY: ${{ secrets.RPM_GPG_KEY }}
+          RPM_GPG_NAME: ${{ secrets.RPM_GPG_NAME }}
         run: |
           chmod +x scripts/package-deb.sh
           VERSION=${GITHUB_REF_NAME#v}
           ./scripts/package-deb.sh $VERSION
           mv orbiscreen_${VERSION}_amd64.deb orbiscreen_amd64.deb
+          
+          echo "Signing DEB package..."
+          sudo apt-get install -y dpkg-sig gnupg2
+          echo "$RPM_GPG_KEY" | gpg --import
+          dpkg-sig -k "$RPM_GPG_NAME" --sign builder orbiscreen_amd64.deb
 
       - name: Package RPM package
         env:
@@ -68,7 +76,12 @@ jobs:
           rpmsign --addsign orbiscreen_x86_64.rpm
 
       - name: Package AppImage
+        env:
+          RPM_GPG_KEY: ${{ secrets.RPM_GPG_KEY }}
+          SIGN: 1
         run: |
+          echo "Importing GPG key for AppImage..."
+          echo "$RPM_GPG_KEY" | gpg2 --import
           chmod +x scripts/package-appimage.sh
           VERSION=${GITHUB_REF_NAME#v}
           ./scripts/package-appimage.sh $VERSION
@@ -80,8 +93,11 @@ jobs:
           java-version: 17
 
       - name: Build Android Release APK
+        env:
+          ANDROID_KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_B64 }}
         run: |
           cd clients/android
+          echo "$ANDROID_KEYSTORE_B64" | base64 -d > orbiscreen-release.keystore
           chmod +x gradlew
           ./gradlew assembleRelease
           cp app/build/outputs/apk/release/app-release.apk ../../orbiscreen-android-release.apk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-All notable changes to **Orbiscreen** are documented here.
+## [0.8.8] - 2026-07-26
+
+### 🚀 Added
+- **Security:** Universal artifact signing implemented.
+- **Android:** The release APK is now cryptographically signed with a production Keystore to prevent "Untrusted Developer" warnings.
+- **Linux:** RPM, DEB, and AppImage packages are now cryptographically signed with GPG keys (`orbiscreen.asc`).
+
+---
 
 ## [v0.7.4] - 2026-07-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-capture"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "ashpd",
  "enumflags2",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-core"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "serde",
  "thiserror 2.0.19",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-daemon"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "clap",
  "hostname",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-display"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "evdi",
  "evdi-sys 0.4.0",
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-encode"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "gstreamer",
  "gstreamer-app",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-gtk"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "gtk4",
  "libadwaita",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-input"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "ashpd",
  "enumflags2",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-transport"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "axum",
  "gstreamer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.7"
+version = "0.8.8"
 edition = "2021"
 rust-version = "1.75"
 license = "GPL-3.0-or-later"

--- a/clients/android/app/build.gradle.kts
+++ b/clients/android/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "com.orbiscreen.android"
         minSdk = 26
         targetSdk = 35
-        versionCode = 5
-        versionName = "0.8.7"
+        versionCode = 6
+        versionName = "0.8.8"
     }
 
     signingConfigs {

--- a/gen-key-script
+++ b/gen-key-script
@@ -1,0 +1,11 @@
+%echo Generating a standard key
+Key-Type: RSA
+Key-Length: 3072
+Subkey-Type: RSA
+Subkey-Length: 3072
+Name-Real: Orbiscreen Builder
+Name-Email: builder@orbiscreen.local
+Expire-Date: 0
+%no-protection
+%commit
+%echo done

--- a/scripts/package-appimage.sh
+++ b/scripts/package-appimage.sh
@@ -40,7 +40,12 @@ echo "[Orbiscreen] Downloading appimagetool..."
 wget -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" -O appimagetool
 chmod +x appimagetool
 
-echo "[Orbiscreen] Building AppImage file..."
-./appimagetool --appimage-extract-and-run "${APPDIR}" "${APPIMAGE_NAME}"
+if [ "${SIGN:-0}" = "1" ]; then
+    echo "[Orbiscreen] Building and signing AppImage file..."
+    ./appimagetool --appimage-extract-and-run --sign "${APPDIR}" "${APPIMAGE_NAME}"
+else
+    echo "[Orbiscreen] Building AppImage file..."
+    ./appimagetool --appimage-extract-and-run "${APPDIR}" "${APPIMAGE_NAME}"
+fi
 
 echo "[Orbiscreen] AppImage built successfully: ${APPIMAGE_NAME}"


### PR DESCRIPTION
Bumps version to v0.8.8 and adds cryptographic signing to APK, DEB, and AppImage artifacts.