### PR TITLE
orbiscreen | v0.9.0 | release: bump to 0.9.0 and fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,26 @@
 # Changelog
 
-## [0.8.8] - 2026-07-26
+## [v0.9.0] - 2026-07-26
 
 ### 🚀 Added
 - **Security:** Universal artifact signing implemented.
 - **Android:** The release APK is now cryptographically signed with a production Keystore to prevent "Untrusted Developer" warnings.
 - **Linux:** RPM, DEB, and AppImage packages are now cryptographically signed with GPG keys (`orbiscreen.asc`).
+
+---
+
+## [v0.8.7] - 2026-07-26
+
+### 🚀 Added
+- **Architecture Migration:** Completely migrated the internal streaming architecture from WebRTC/WebView to a native GStreamer pipeline.
+- **Android Native Player:** Replaced the heavy, stuttering WebView with a fully native hardware-accelerated ExoPlayer implementation.
+- **Zero-Config Discovery:** Implemented mDNS service discovery; the Android app now automatically discovers and connects to the Orbiscreen daemon without manual IP entry.
+- **Touch Input Injection:** Touch events on the Android screen are now streamed back and injected directly into the Linux Wayland compositor using `uinput` and `evdev`.
+
+### 🐛 Fixed
+- **Latency & Performance:** Solved severe latency and dropped frames issues on older Android devices.
+- **Wayland Compatibility:** Removed the failing EVDI dependency. The capture backend now robustly utilizes the XDG Desktop Portal for Wayland/X11 screen capture.
+- **CI/CD Reliability:** Fixed various `cargo fmt` errors, `clippy` warnings, and `Cargo.lock` drift issues in the GitHub Actions workflow.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-capture"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "ashpd",
  "enumflags2",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-core"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "serde",
  "thiserror 2.0.19",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-daemon"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "clap",
  "hostname",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-display"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "evdi",
  "evdi-sys 0.4.0",
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-encode"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "gstreamer",
  "gstreamer-app",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-gtk"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "gtk4",
  "libadwaita",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-input"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "ashpd",
  "enumflags2",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "orbiscreen-transport"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "axum",
  "gstreamer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.8"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.75"
 license = "GPL-3.0-or-later"

--- a/clients/android/app/build.gradle.kts
+++ b/clients/android/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "com.orbiscreen.android"
         minSdk = 26
         targetSdk = 35
-        versionCode = 6
-        versionName = "0.8.8"
+        versionCode = 7
+        versionName = "0.9.0"
     }
 
     signingConfigs {


### PR DESCRIPTION
Bumps version to v0.9.0 and adds missing 0.8.x history to CHANGELOG.md. Fixes CHANGELOG headers so GitHub Actions can extract release notes correctly.