### PR TITLE
orbiscreen | fix: restore direct touch as a virtual multitouch device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🐛 Fixed
+- **Direct Touch Injected as Mouse (`orbiscreen-input`, Android Client)**:
+  - v0.22.3 stopped writing to `Orbiscreen Virtual Touchscreen` (marked `dead_code`) and routed every Android touch through the virtual mouse as `Pointer` Move/Button, so a finger only moved the host cursor.
+  - Android Direct Touch mode now posts a per-finger `Touch` event (`slot`, `id`, `x`, `y`, `pressed`) instead of a mouse pointer payload.
+  - The host injects evdev type-B multitouch (`ABS_MT_SLOT`, `ABS_MT_TRACKING_ID`, `ABS_MT_POSITION_X/Y`, `BTN_TOUCH`) on the dedicated touchscreen bound to `Virtual-ORBISCREEN`.
+  - Touchpad mode is unchanged.
+
 ## [v0.22.8] - 2026-09-05
 
 Embed full multi-vendor Android udev rules in `orbiscreen doctor --fix`, implement resilient token retry logic on Android client to eliminate initial unauthorized stream errors, and provide zero-root USB Tethering guidance.

--- a/clients/android/app/src/main/java/com/orbiscreen/android/input/InputDispatcher.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/input/InputDispatcher.kt
@@ -49,6 +49,7 @@ class InputDispatcher(
 
     private val latestMove = java.util.concurrent.atomic.AtomicReference<JSONObject?>(null)
     private val latestStylus = java.util.concurrent.atomic.AtomicReference<JSONObject?>(null)
+    private val latestTouches = java.util.concurrent.ConcurrentHashMap<Int, JSONObject>()
     private var lastStylusPressure: Float = 0f
 
     private val discrete = MutableSharedFlow<JSONObject>(
@@ -85,6 +86,12 @@ class InputDispatcher(
                 val st = latestStylus.getAndSet(null)
                 if (st != null) {
                     send(st)
+                }
+                if (latestTouches.isNotEmpty()) {
+                    val slots = latestTouches.keys.toList()
+                    for (slot in slots) {
+                        latestTouches.remove(slot)?.let { send(it) }
+                    }
                 }
                 kotlinx.coroutines.delay(16)
             }
@@ -213,6 +220,35 @@ class InputDispatcher(
             })
         }
         discrete.tryEmit(payload)
+    }
+
+    fun touch(
+        slot: Int,
+        id: Int,
+        localX: Float,
+        localY: Float,
+        containerW: Int,
+        containerH: Int,
+        pressed: Boolean,
+        coalesce: Boolean = false,
+    ) {
+        val (x, y) = map(localX, localY, containerW, containerH)
+        val payload = JSONObject().apply {
+            put("Touch", JSONObject().apply {
+                put("slot", slot)
+                put("id", id)
+                put("x", x.toDouble())
+                put("y", y.toDouble())
+                put("pressed", pressed)
+            })
+        }
+        if (coalesce && pressed) {
+            latestTouches[slot] = payload
+        } else {
+            latestTouches.remove(slot)
+            discrete.tryEmit(payload)
+            Log.d(TAG, "touch slot=$slot id=$id pressed=$pressed")
+        }
     }
 
     fun stylus(

--- a/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/PlayerSurface.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/PlayerSurface.kt
@@ -42,6 +42,7 @@ private class TouchCallbacksHolder(
     var isTouchMode: Boolean,
     var onMove: (Float, Float, Int, Int) -> Unit,
     var onPointer: (Float?, Float?, Int, Int, Int, Boolean) -> Unit,
+    var onTouch: (Int, Int, Float, Float, Int, Int, Boolean, Boolean) -> Unit,
     var onDeltaMove: (Float, Float) -> Unit,
     var onLeftClick: () -> Unit,
     var onRightClick: () -> Unit,
@@ -58,6 +59,7 @@ fun PlayerSurface(
     isTouchMode: Boolean,
     onMove: (Float, Float, Int, Int) -> Unit,
     onPointer: (Float?, Float?, Int, Int, Int, Boolean) -> Unit,
+    onTouch: (Int, Int, Float, Float, Int, Int, Boolean, Boolean) -> Unit,
     onDeltaMove: (Float, Float) -> Unit,
     onLeftClick: () -> Unit,
     onRightClick: () -> Unit,
@@ -74,6 +76,7 @@ fun PlayerSurface(
             isTouchMode = isTouchMode,
             onMove = onMove,
             onPointer = onPointer,
+            onTouch = onTouch,
             onDeltaMove = onDeltaMove,
             onLeftClick = onLeftClick,
             onRightClick = onRightClick,
@@ -87,6 +90,7 @@ fun PlayerSurface(
     holder.scaleMode = scaleMode
     holder.onMove = onMove
     holder.onPointer = onPointer
+    holder.onTouch = onTouch
     holder.onDeltaMove = onDeltaMove
     holder.onLeftClick = onLeftClick
     holder.onRightClick = onRightClick
@@ -162,39 +166,42 @@ fun PlayerSurface(
 
                     if (holder.isTouchMode) {
                         val cr = computeContentRect(w, hPx, streamWidth, streamHeight, holder.scaleMode)
-                        val cx = (ev.x - cr.offsetX).coerceIn(0f, cr.w)
-                        val cy = (ev.y - cr.offsetY).coerceIn(0f, cr.h)
                         val cw = cr.w.toInt().coerceAtLeast(1)
                         val ch = cr.h.toInt().coerceAtLeast(1)
+                        val mapped = { idx: Int ->
+                            val mx = (ev.getX(idx) - cr.offsetX).coerceIn(0f, cr.w)
+                            val my = (ev.getY(idx) - cr.offsetY).coerceIn(0f, cr.h)
+                            mx to my
+                        }
+                        val emitTouch = { idx: Int, pressed: Boolean, coalesce: Boolean ->
+                            val id = ev.getPointerId(idx)
+                            val slot = id.coerceIn(0, 9)
+                            val (tx, ty) = mapped(idx)
+                            holder.onTouch(slot, id, tx, ty, cw, ch, pressed, coalesce)
+                        }
 
                         when (ev.actionMasked) {
                             MotionEvent.ACTION_DOWN -> {
-                                holder.onPointer(cx, cy, cw, ch, 1, true)
+                                emitTouch(0, true, false)
                             }
                             MotionEvent.ACTION_POINTER_DOWN -> {
-                                val idx = ev.actionIndex
-                                val px = (ev.getX(idx) - cr.offsetX).coerceIn(0f, cr.w)
-                                val py = (ev.getY(idx) - cr.offsetY).coerceIn(0f, cr.h)
-                                holder.onPointer(px, py, cw, ch, 1, true)
+                                emitTouch(ev.actionIndex, true, false)
                             }
                             MotionEvent.ACTION_MOVE -> {
                                 for (i in 0 until ev.pointerCount) {
-                                    val mx = (ev.getX(i) - cr.offsetX).coerceIn(0f, cr.w)
-                                    val my = (ev.getY(i) - cr.offsetY).coerceIn(0f, cr.h)
-                                    holder.onMove(mx, my, cw, ch)
+                                    emitTouch(i, true, true)
                                 }
                             }
                             MotionEvent.ACTION_POINTER_UP -> {
-                                val idx = ev.actionIndex
-                                val px = (ev.getX(idx) - cr.offsetX).coerceIn(0f, cr.w)
-                                val py = (ev.getY(idx) - cr.offsetY).coerceIn(0f, cr.h)
-                                holder.onPointer(px, py, cw, ch, 1, false)
+                                emitTouch(ev.actionIndex, false, false)
                             }
                             MotionEvent.ACTION_UP -> {
-                                holder.onPointer(cx, cy, cw, ch, 1, false)
+                                emitTouch(0, false, false)
                             }
                             MotionEvent.ACTION_CANCEL -> {
-                                holder.onPointer(null, null, cw, ch, 1, false)
+                                for (i in 0 until ev.pointerCount) {
+                                    emitTouch(i, false, false)
+                                }
                             }
                         }
                     } else {

--- a/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/StreamScreen.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/StreamScreen.kt
@@ -243,6 +243,9 @@ fun StreamScreen(
                 onPointer = { x, y, w, h, btn, pressed ->
                     input.pointerAction(x, y, w, h, btn, pressed)
                 },
+                onTouch = { slot, id, x, y, w, h, pressed, coalesce ->
+                    input.touch(slot, id, x, y, w, h, pressed, coalesce)
+                },
                 onDeltaMove = { dx, dy -> input.moveDelta(dx, dy) },
                 onLeftClick = { input.leftClick() },
                 onRightClick = { input.rightClick() },

--- a/crates/orbiscreen-daemon/src/main.rs
+++ b/crates/orbiscreen-daemon/src/main.rs
@@ -2159,6 +2159,11 @@ async fn run_start(
                     };
                     let _ = inj.inject_stylus(s).await;
                 }
+                IncomingInput::Touch(t) => {
+                    let (x, y) = scale(t.x, t.y);
+                    let t = orbiscreen_input::TouchEvent { x, y, ..t };
+                    let _ = inj.inject_touch(t).await;
+                }
                 IncomingInput::RawPointer { x, y } => {
                     let (x, y) = scale(x, y);
                     let _ = inj.inject_pointer(PointerEvent::Move { x, y }).await;

--- a/crates/orbiscreen-input/src/lib.rs
+++ b/crates/orbiscreen-input/src/lib.rs
@@ -19,6 +19,15 @@ pub enum PointerEvent {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct TouchEvent {
+    pub slot: u32,
+    pub id: i32,
+    pub x: f64,
+    pub y: f64,
+    pub pressed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum StylusEvent {
     Proximity {},
     Pressure {
@@ -77,6 +86,7 @@ pub enum InjectorKind {
 }
 
 pub(crate) const MAX_WHEEL_STEPS: i32 = 12;
+pub(crate) const MAX_TOUCH_SLOTS: usize = 10;
 
 #[allow(missing_debug_implementations)]
 enum InjectorInner {
@@ -89,6 +99,7 @@ enum InjectorInner {
 #[allow(missing_debug_implementations)]
 pub struct InputInjector {
     inner: InjectorInner,
+    fallback_touch_down: bool,
 }
 
 impl InputInjector {
@@ -101,6 +112,7 @@ impl InputInjector {
                         info!("input injection via XTEST (rootless)");
                         Ok(Self {
                             inner: InjectorInner::Xtest(Box::new(injector)),
+                            fallback_touch_down: false,
                         })
                     }
                     Err(e) => {
@@ -109,6 +121,7 @@ impl InputInjector {
                             inner: InjectorInner::Uinput(Box::new(x11::UinputInjector::open(
                                 spec_for_uinput,
                             )?)),
+                            fallback_touch_down: false,
                         })
                     }
                 }
@@ -121,6 +134,7 @@ impl InputInjector {
                     );
                     return Ok(Self {
                         inner: InjectorInner::Uinput(Box::new(injector)),
+                        fallback_touch_down: false,
                     });
                 }
 
@@ -134,6 +148,7 @@ impl InputInjector {
                     info!("input injection via wlroots virtual protocols");
                     return Ok(Self {
                         inner: InjectorInner::Wlroots(Box::new(injector)),
+                        fallback_touch_down: false,
                     });
                 }
 
@@ -146,6 +161,7 @@ impl InputInjector {
                 {
                     Ok(Ok(injector)) => Ok(Self {
                         inner: InjectorInner::Portal(Box::new(injector)),
+                        fallback_touch_down: false,
                     }),
                     Ok(Err(portal_error)) => {
                         warn!("portal RemoteDesktop failed: {portal_error}");
@@ -187,6 +203,38 @@ impl InputInjector {
             InjectorInner::Portal(injector) => injector.inject_key(event).await,
             InjectorInner::Wlroots(injector) => injector.inject_key(event).await,
         }
+    }
+
+    pub async fn inject_touch(&mut self, event: TouchEvent) -> Result<(), InputError> {
+        if let InjectorInner::Uinput(injector) = &mut self.inner {
+            return injector.inject_touch(event);
+        }
+        if event.slot != 0 {
+            return Ok(());
+        }
+        if event.pressed {
+            self.inject_pointer(PointerEvent::Move {
+                x: event.x,
+                y: event.y,
+            })
+            .await?;
+            if !self.fallback_touch_down {
+                self.fallback_touch_down = true;
+                self.inject_pointer(PointerEvent::Button {
+                    button: 1,
+                    pressed: true,
+                })
+                .await?;
+            }
+        } else if self.fallback_touch_down {
+            self.fallback_touch_down = false;
+            self.inject_pointer(PointerEvent::Button {
+                button: 1,
+                pressed: false,
+            })
+            .await?;
+        }
+        Ok(())
     }
 
     pub async fn inject_stylus(&mut self, event: StylusEvent) -> Result<(), InputError> {
@@ -297,6 +345,24 @@ mod tests {
                 "button {button} maps to {code:#x}, outside registered key range"
             );
         }
+    }
+
+    #[test]
+    fn touch_event_json_uses_snake_case_field_names() {
+        let json = serde_json::json!({
+            "Touch": {"slot": 1, "id": 4, "x": 10.0, "y": 20.0, "pressed": true}
+        });
+        #[derive(serde::Deserialize)]
+        struct W {
+            #[serde(rename = "Touch")]
+            touch: TouchEvent,
+        }
+        let w: W = serde_json::from_value(json).expect("touch payload");
+        assert_eq!(w.touch.slot, 1);
+        assert_eq!(w.touch.id, 4);
+        assert_eq!(w.touch.x, 10.0);
+        assert_eq!(w.touch.y, 20.0);
+        assert!(w.touch.pressed);
     }
 
     #[test]

--- a/crates/orbiscreen-input/src/x11.rs
+++ b/crates/orbiscreen-input/src/x11.rs
@@ -10,7 +10,7 @@ use evdevil::uinput::{AbsSetup, UinputDevice};
 use evdevil::{AbsInfo, Bus, InputId, InputProp};
 use tracing::info;
 
-use super::{InputError, PointerEvent, StylusEvent, VirtualTouchscreenSpec};
+use super::{InputError, PointerEvent, StylusEvent, TouchEvent, VirtualTouchscreenSpec};
 
 const PRESSURE_MAX: i32 = 1024;
 const TILT_MIN: i32 = -90;
@@ -25,13 +25,14 @@ impl From<io::Error> for InputError {
 #[allow(missing_debug_implementations)]
 pub struct UinputInjector {
     mouse_keyboard: UinputDevice,
-    #[allow(dead_code)]
     touchscreen: UinputDevice,
     tablet: UinputDevice,
     width: u32,
     height: u32,
     last_touch_x: i32,
     last_touch_y: i32,
+    touch_slot_active: [bool; crate::MAX_TOUCH_SLOTS],
+    touch_active_count: u8,
 }
 
 impl UinputInjector {
@@ -53,12 +54,18 @@ impl UinputInjector {
             .with_keys(mk_keys)?
             .build("Orbiscreen Virtual Mouse and Keyboard")?;
 
+        let slot_axis = AbsInfo::new(0, (crate::MAX_TOUCH_SLOTS as i32) - 1);
+        let tracking_axis = AbsInfo::new(-1, i32::MAX);
         let touchscreen = UinputDevice::builder()?
             .with_input_id(InputId::new(Bus::VIRTUAL, 0x0BEE, 0x0002, 0x0001))?
             .with_props([InputProp::DIRECT])?
             .with_abs_axes([
                 AbsSetup::new(Abs::X, width_axis),
                 AbsSetup::new(Abs::Y, height_axis),
+                AbsSetup::new(Abs::MT_SLOT, slot_axis),
+                AbsSetup::new(Abs::MT_TRACKING_ID, tracking_axis),
+                AbsSetup::new(Abs::MT_POSITION_X, width_axis),
+                AbsSetup::new(Abs::MT_POSITION_Y, height_axis),
             ])?
             .with_keys([Key::BTN_TOUCH])?
             .build("Orbiscreen Virtual Touchscreen")?;
@@ -97,6 +104,8 @@ impl UinputInjector {
             height: spec.height,
             last_touch_x: 0,
             last_touch_y: 0,
+            touch_slot_active: [false; crate::MAX_TOUCH_SLOTS],
+            touch_active_count: 0,
         })
     }
 
@@ -192,6 +201,53 @@ impl UinputInjector {
             SynEvent::new(Syn::REPORT).into(),
         ];
         self.mouse_keyboard.write_events(&events)?;
+        Ok(())
+    }
+
+    pub fn inject_touch(&mut self, event: TouchEvent) -> Result<(), InputError> {
+        let slot = (event.slot as usize).min(crate::MAX_TOUCH_SLOTS - 1);
+        let (xi, yi) = self.clamp_point(event.x, event.y);
+        if event.pressed {
+            self.last_touch_x = xi;
+            self.last_touch_y = yi;
+        }
+        let tracking_id = if event.id >= 0 { event.id } else { slot as i32 };
+        let becoming_active = event.pressed && !self.touch_slot_active[slot];
+        let becoming_idle = !event.pressed && self.touch_slot_active[slot];
+        if becoming_active {
+            self.touch_slot_active[slot] = true;
+            self.touch_active_count = self.touch_active_count.saturating_add(1);
+        } else if becoming_idle {
+            self.touch_slot_active[slot] = false;
+            self.touch_active_count = self.touch_active_count.saturating_sub(1);
+        } else if !event.pressed {
+            return Ok(());
+        }
+
+        let mut writer = self.touchscreen.writer();
+        let mut slot_writer = writer.slot(slot as u16)?;
+        if becoming_active {
+            slot_writer = slot_writer.set_tracking_id(tracking_id)?;
+        }
+        if event.pressed {
+            slot_writer = slot_writer.set_position(xi, yi)?;
+        }
+        if becoming_idle {
+            slot_writer = slot_writer.set_tracking_id(-1)?;
+        }
+        writer = slot_writer.finish_slot()?;
+        if event.pressed {
+            writer = writer.write_events(&[
+                AbsEvent::new(Abs::X, xi).into(),
+                AbsEvent::new(Abs::Y, yi).into(),
+            ])?;
+        }
+        if becoming_active && self.touch_active_count == 1 {
+            writer = writer.write_events(&[KEv::new(Key::BTN_TOUCH, KeyState::PRESSED).into()])?;
+        } else if becoming_idle && self.touch_active_count == 0 {
+            writer = writer.write_events(&[KEv::new(Key::BTN_TOUCH, KeyState::RELEASED).into()])?;
+        }
+        writer.finish()?;
         Ok(())
     }
 

--- a/crates/orbiscreen-transport/src/lib.rs
+++ b/crates/orbiscreen-transport/src/lib.rs
@@ -34,13 +34,14 @@ pub enum TransportError {
     Http(String),
 }
 
-use orbiscreen_input::{KeyEvent, PointerEvent, StylusEvent};
+use orbiscreen_input::{KeyEvent, PointerEvent, StylusEvent, TouchEvent};
 
 #[derive(Debug, Clone, serde::Deserialize)]
 pub enum IncomingInput {
     Pointer(PointerEvent),
     Key(KeyEvent),
     Stylus(StylusEvent),
+    Touch(TouchEvent),
     #[serde(untagged)]
     RawPointer {
         x: f64,
@@ -865,5 +866,23 @@ mod tests {
         stats.note_auth_failure();
         stats.note_auth_failure();
         assert_eq!(stats.auth_failures(), 2);
+    }
+
+    #[test]
+    fn incoming_input_parses_touch_payload() {
+        let json = serde_json::json!({
+            "Touch": {"slot": 2, "id": 7, "x": 100.0, "y": 200.0, "pressed": true}
+        });
+        let ev: IncomingInput = serde_json::from_value(json).expect("touch payload");
+        match ev {
+            IncomingInput::Touch(t) => {
+                assert_eq!(t.slot, 2);
+                assert_eq!(t.id, 7);
+                assert_eq!(t.x, 100.0);
+                assert_eq!(t.y, 200.0);
+                assert!(t.pressed);
+            }
+            other => panic!("expected Touch, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Restores Direct Touch as a real virtual touchscreen instead of a mouse.

Android Direct Touch mode now sends a per-finger `Touch` payload (`slot`, `id`, `x`, `y`, `pressed`). The host injects those events onto `Orbiscreen Virtual Touchscreen` with evdev type-B multitouch (`ABS_MT_SLOT`, `ABS_MT_TRACKING_ID`, `ABS_MT_POSITION_X/Y`, `BTN_TOUCH`). Touchpad mode still uses the virtual mouse.

### Why?

v0.22.3 (`1f4e867`) stopped writing to `Orbiscreen Virtual Touchscreen` (marked `dead_code`) and routed every Android touch through the virtual mouse as `Pointer` Move/Button. Moving a finger on the tablet therefore moved the host cursor instead of generating touch contacts.

See the `[Unreleased]` entry in `CHANGELOG.md`.

### How was it tested?

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (changed crates: `orbiscreen-input`, `orbiscreen-transport`, `orbiscreen-daemon`)
- [x] `cargo test --workspace` (ran `orbiscreen-input` and `orbiscreen-transport`, including new Touch JSON tests)
- [x] Manual smoke test on: KDE Plasma Wayland + Samsung Galaxy Tab S5e (SM-T725, Android 11). Local daemon `target/debug/orbiscreen start`; debug APK installed over USB. A swipe on the streamed YouTube window scrolled the page instead of moving the mouse cursor. `adb logcat` showed `Orbi.Input: touch slot=0 id=0 pressed=…`.

### Checklist

- [x] No new warnings introduced.
- [x] File headers match UMO style (`// Orbiscreen - <module> (GPL-3.0-or-later)` + GitHub URL).
- [x] `CHANGELOG.md` updated.