### PR TITLE
orbiscreen | fix: shrink HTTP MPEG-TS transport queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### ⚡ Performance & Low Latency
+- **HTTP MPEG-TS Transport Queue (`orbiscreen-transport`, Android, Web)**:
+  - Per-client muxer keeps four sink buffers and a 16-slot HTTP queue instead of 512 / 1024 queued chunks.
+  - HTTP send no longer drops MPEG-TS packets on a full queue (that desynced the decoder). The muxer backpressures instead; a stalled `appsrc` push resyncs on the next keyframe.
+  - Android ExoPlayer live offset cut to 24 ms (8–48 ms) with 32–64 ms load control, `FEATURE_LowLatency` decoder preference, and MediaCodec low-latency flags.
+  - Web `mpegts.js` live sync target cut to 30 ms with a tighter latency chase.
+
 ## [v0.23.3] - 2026-09-06
 
 Enable Gradle dependency caching in CI workflows to eliminate Cloudflare 403 Forbidden errors; enhance in-page Code of Conduct navigation anchors.

--- a/clients/android/app/src/main/java/com/orbiscreen/android/player/PlayerHolder.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/player/PlayerHolder.kt
@@ -4,13 +4,17 @@
 package com.orbiscreen.android.player
 
 import android.content.Context
+import android.media.MediaCrypto
+import android.media.MediaFormat
 import android.net.Uri
+import android.os.Build
+import android.os.Handler
 import android.util.Log
 import androidx.annotation.OptIn
+import androidx.media3.common.Format
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.PlaybackException
-import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
@@ -18,11 +22,16 @@ import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.mediacodec.MediaCodecAdapter
 import androidx.media3.exoplayer.mediacodec.MediaCodecInfo
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.video.MediaCodecVideoRenderer
+import androidx.media3.exoplayer.video.VideoRendererEventListener
 import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory
+import java.util.ArrayList
 import com.orbiscreen.android.data.PrefsStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -127,7 +136,7 @@ class PlayerHolder(
             val mediaSourceFactory = DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory)
 
             val loadControl = DefaultLoadControl.Builder()
-                .setBufferDurationsMs(40, 120, 25, 40)
+                .setBufferDurationsMs(32, 64, 16, 32)
                 .setPrioritizeTimeOverSizeThresholds(true)
                 .build()
 
@@ -141,11 +150,11 @@ class PlayerHolder(
                         .setMimeType(MimeTypes.VIDEO_MP2T)
                         .setLiveConfiguration(
                             MediaItem.LiveConfiguration.Builder()
-                                .setTargetOffsetMs(40)
-                                .setMinOffsetMs(25)
-                                .setMaxOffsetMs(120)
-                                .setMinPlaybackSpeed(0.97f)
-                                .setMaxPlaybackSpeed(1.03f)
+                                .setTargetOffsetMs(24)
+                                .setMinOffsetMs(8)
+                                .setMaxOffsetMs(48)
+                                .setMinPlaybackSpeed(0.95f)
+                                .setMaxPlaybackSpeed(1.08f)
                                 .build()
                         )
                         .build()
@@ -153,6 +162,7 @@ class PlayerHolder(
                     repeatMode = Player.REPEAT_MODE_OFF
                     playWhenReady = true
                     volume = 0f
+                    setForegroundMode(true)
                     addListener(object : Player.Listener {
                         override fun onPlaybackStateChanged(state: Int) {
                             when (state) {
@@ -244,25 +254,47 @@ class PlayerHolder(
         }
 
     private fun buildRenderersFactory(): DefaultRenderersFactory {
-        val factory = DefaultRenderersFactory(context)
+        val selector = if (prefs.forceSoftwareDecoder) {
+            MediaCodecSelector { mimeType, secure, tunneling ->
+                MediaCodecSelector.DEFAULT
+                    .getDecoderInfos(mimeType, secure, tunneling)
+                    .filter { !it.hardwareAccelerated }
+            }
+        } else {
+            MediaCodecSelector { mimeType, secure, tunneling ->
+                val all = MediaCodecSelector.DEFAULT.getDecoderInfos(mimeType, secure, tunneling)
+                val lowLatency = all.filter { info ->
+                    info.hardwareAccelerated &&
+                        info.capabilities?.isFeatureSupported("low-latency") == true
+                }
+                (lowLatency + all.filter { it.hardwareAccelerated } + all).distinct()
+            }
+        }
+        return object : DefaultRenderersFactory(context) {
+            override fun buildVideoRenderers(
+                context: Context,
+                extensionRendererMode: Int,
+                mediaCodecSelector: MediaCodecSelector,
+                enableDecoderFallback: Boolean,
+                eventHandler: Handler,
+                eventListener: VideoRendererEventListener,
+                allowedVideoJoiningTimeMs: Long,
+                out: ArrayList<Renderer>,
+            ) {
+                out.add(
+                    LowLatencyVideoRenderer(
+                        context,
+                        mediaCodecSelector,
+                        enableDecoderFallback,
+                        eventHandler,
+                        eventListener,
+                    ),
+                )
+            }
+        }
             .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF)
             .setEnableDecoderFallback(true)
-        if (prefs.forceSoftwareDecoder) {
-            factory.setMediaCodecSelector(
-                object : MediaCodecSelector {
-                    override fun getDecoderInfos(
-                        mimeType: String,
-                        requiresSecureDecoder: Boolean,
-                        requiresTunnelingDecoder: Boolean,
-                    ): List<MediaCodecInfo> {
-                        return MediaCodecSelector.DEFAULT
-                            .getDecoderInfos(mimeType, requiresSecureDecoder, requiresTunnelingDecoder)
-                            .filter { !it.hardwareAccelerated }
-                    }
-                },
-            )
-        }
-        return factory
+            .setMediaCodecSelector(selector)
     }
 
     private fun scheduleReconnect() {
@@ -316,5 +348,43 @@ class PlayerHolder(
 
     fun retry(host: String, port: Int, tokenProvider: suspend () -> String = { "" }) {
         scope.launch { build(host, port, tokenProvider) }
+    }
+}
+
+@OptIn(UnstableApi::class)
+private class LowLatencyVideoRenderer(
+    context: Context,
+    mediaCodecSelector: MediaCodecSelector,
+    enableDecoderFallback: Boolean,
+    eventHandler: Handler,
+    eventListener: VideoRendererEventListener,
+) : MediaCodecVideoRenderer(
+    context,
+    mediaCodecSelector,
+    0L,
+    enableDecoderFallback,
+    eventHandler,
+    eventListener,
+    50,
+) {
+    override fun getMediaCodecConfiguration(
+        codecInfo: MediaCodecInfo,
+        format: Format,
+        crypto: MediaCrypto?,
+        codecOperatingRate: Float,
+    ): MediaCodecAdapter.Configuration {
+        val config = super.getMediaCodecConfiguration(codecInfo, format, crypto, codecOperatingRate)
+        val mediaFormat = config.mediaFormat
+        if (Build.VERSION.SDK_INT >= 30) {
+            mediaFormat.setInteger(MediaFormat.KEY_LOW_LATENCY, 1)
+        }
+        if (Build.VERSION.SDK_INT >= 23) {
+            mediaFormat.setInteger(MediaFormat.KEY_PRIORITY, 0)
+            mediaFormat.setInteger(MediaFormat.KEY_OPERATING_RATE, Short.MAX_VALUE.toInt())
+        }
+        mediaFormat.setInteger("low-latency", 1)
+        mediaFormat.setInteger("vdec-lowlatency", 1)
+        mediaFormat.setInteger("vendor.low-latency.enable", 1)
+        return config
     }
 }

--- a/clients/web/app.js
+++ b/clients/web/app.js
@@ -984,10 +984,10 @@ function startStream() {
         lazyLoadMaxDuration: 0,
         seekType: "range",
         liveBufferLatencyChasing: true,
-        liveBufferLatencyMaxLatency: 0.2,
-        liveBufferLatencyMinRemain: 0.05,
+        liveBufferLatencyMaxLatency: 0.08,
+        liveBufferLatencyMinRemain: 0.016,
         liveSync: true,
-        liveSyncTargetLatency: 0.05,
+        liveSyncTargetLatency: 0.03,
     });
 
     videoEl.muted = true;
@@ -1030,8 +1030,8 @@ function startStream() {
             const delay = end - videoEl.currentTime;
             const ms = Math.max(0, Math.round(delay * 1000));
             if (statLatency) statLatency.textContent = `${ms} ms`;
-            if (delay > 0.3) {
-                videoEl.currentTime = end - 0.03;
+            if (delay > 0.08) {
+                videoEl.currentTime = end - 0.02;
             }
         } catch (_) {}
     }, 250);

--- a/crates/orbiscreen-transport/src/lib.rs
+++ b/crates/orbiscreen-transport/src/lib.rs
@@ -628,11 +628,11 @@ async fn stream_handler(State(state): State<AppState>) -> axum::response::Respon
 
     gstreamer::init().ok();
 
-    let pipeline_str = "appsrc name=src format=time is-live=false \
+    let pipeline_str = "appsrc name=src format=time is-live=false block=false \
                         ! video/x-h264,stream-format=byte-stream,alignment=au \
                         ! h264parse config-interval=1 \
                         ! mpegtsmux alignment=7 \
-                        ! appsink name=sink drop=false sync=false max-buffers=64 emit-signals=false";
+                        ! appsink name=sink drop=false sync=false max-buffers=4 emit-signals=false";
     let pipeline = match gstreamer::parse::launch(pipeline_str) {
         Ok(p) => match p.downcast::<gstreamer::Pipeline>() {
             Ok(pipeline) => pipeline,
@@ -664,6 +664,8 @@ async fn stream_handler(State(state): State<AppState>) -> axum::response::Respon
         .build();
     appsrc.set_caps(Some(&caps));
     appsrc.set_format(gstreamer::Format::Time);
+    appsrc.set_max_bytes(512 * 1024);
+    appsrc.set_block(false);
 
     let appsink = match pipeline
         .by_name("sink")
@@ -676,7 +678,7 @@ async fn stream_handler(State(state): State<AppState>) -> axum::response::Respon
         }
     };
 
-    let (tx, rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+    let (tx, rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
     let tx_alive = tx.clone();
     appsink.set_callbacks(
         AppSinkCallbacks::builder()
@@ -773,8 +775,13 @@ async fn stream_handler(State(state): State<AppState>) -> axum::response::Respon
             let mut normalized = pkt;
             normalized.pts_ns = normalized.pts_ns.saturating_sub(base);
 
-            if push_h264_packet(&appsrc_clone, &normalized).is_err() {
-                break;
+            if let Err(e) = push_h264_packet(&appsrc_clone, &normalized) {
+                match e {
+                    gstreamer::FlowError::Flushing | gstreamer::FlowError::Eos => break,
+                    _ => {
+                        wait_keyframe = true;
+                    }
+                }
             }
         }
         let _ = pipeline.set_state(gstreamer::State::Null);

--- a/crates/orbiscreen-transport/tests/mpegts_mux_timestamps.rs
+++ b/crates/orbiscreen-transport/tests/mpegts_mux_timestamps.rs
@@ -87,11 +87,11 @@ fn mpegts_muxer_emits_for_daemon_normalized_timestamps() {
 
 fn mux_to_ts(chunks: Vec<(Vec<u8>, bool, u64)>) -> usize {
     let pipeline = gstreamer::parse::launch(
-        "appsrc name=src format=time is-live=false \
+        "appsrc name=src format=time is-live=false block=false \
          ! video/x-h264,stream-format=byte-stream,alignment=au,framerate=60/1 \
          ! h264parse config-interval=1 \
          ! mpegtsmux alignment=7 \
-         ! appsink name=sink drop=false sync=false max-buffers=256",
+         ! appsink name=sink drop=false sync=false max-buffers=4",
     )
     .unwrap()
     .downcast::<gstreamer::Pipeline>()


### PR DESCRIPTION
**Latency stack (merge in this order):** #70 → #71 → #72.

This is the first PR in a latency-improvement series. I will follow with more of those. Merge this first; #71 and #72 are stacked on this commit.

### What does this PR do?

Cuts the HTTP MPEG-TS queue that sat between the muxer and the client.

The per-client muxer now keeps four sink buffers and a 16-slot HTTP channel. Send backpressures instead of dropping TS packets (dropped packets desynced ExoPlayer to a black screen). A stalled `appsrc` push resyncs on the next keyframe. Android live offset is 24 ms with MediaCodec low-latency flags; the web client live-sync target is 30 ms.

### Why?

v0.23.2 already stopped dropping mid-stream TS chunks (`max-buffers=64`, HTTP queue 64). Those queues still park a lot of video before the decoder. This goes further: 4 / 16, no drop on a full HTTP queue, and tighter ExoPlayer / mpegts.js live offsets.

See the `[Unreleased]` entry in `CHANGELOG.md`.

### How was it tested?

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (changed crates: `orbiscreen-transport`; GTK excluded)
- [x] `cargo test --workspace` (ran `orbiscreen-transport`, including `mpegts_muxer_emits_for_daemon_normalized_timestamps`)
- [x] Manual smoke test on: KDE Plasma Wayland + Samsung Galaxy Tab S5e (SM-T725, Android 11). Local daemon `target/debug/orbiscreen start`; debug APK over USB. `/health` reported `encoder=vaapi`, `active_clients=1`, and the tablet showed the virtual display (YouTube) without a black screen.

### Checklist

- [x] No new warnings introduced.
- [x] File headers match Orbiscreen style (`// Orbiscreen - <module> (GPL-3.0-or-later)` + GitHub URL).
- [x] `CHANGELOG.md` updated.