### PR TITLE
orbiscreen | feat: infinite GOP with intra-refresh and on-demand IDR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Confine trackpad pointer motion and clicks to the virtual display via virtual ta
 ## [Unreleased]
 
 ### ⚡ Performance & Low Latency
+- **Hardware H.264 Encoder Detection (`orbiscreen-encode`)**:
+  - Auto now selects GStreamer `vah264enc` (current VA plugin) as well as legacy `vaapih264enc` / `nvh264enc` / `nvcudah264enc`.
+  - Falling back to software `x264enc` logs a warning instead of silently encoding 1440p+ on the CPU.
+  - `vah264enc` is tuned for low latency (`cbr`, `target-usage=7`, one reference frame, no B-frames).
 - **HTTP MPEG-TS Transport Queue (`orbiscreen-transport`, Android, Web)**:
   - Per-client muxer keeps four sink buffers and a 16-slot HTTP queue instead of 512 / 1024 queued chunks.
   - HTTP send no longer drops MPEG-TS packets on a full queue (that desynced the decoder). The muxer backpressures instead; a stalled `appsrc` push resyncs on the next keyframe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Confine trackpad pointer motion and clicks to the virtual display via virtual ta
 ## [Unreleased]
 
 ### ⚡ Performance & Low Latency
+- **Infinite GOP + On-Demand IDR (`orbiscreen-encode`, `orbiscreen-transport`, Android, Web)**:
+  - Encoders no longer emit a keyframe every 60 frames. GOP length uses the encoder maximum (`key-int-max` / `gop-size`); `x264enc` also enables periodic intra-refresh.
+  - Clients request a recovery IDR via `POST /api/control` (`action: idr`). A new `/stream` client and a lagged muxer do the same.
+  - The encoder src pad receives an upstream `GstForceKeyUnit` (all-headers), debounced to 200 ms.
 - **Hardware H.264 Encoder Detection (`orbiscreen-encode`)**:
   - Auto now selects GStreamer `vah264enc` (current VA plugin) as well as legacy `vaapih264enc` / `nvh264enc` / `nvcudah264enc`.
   - Falling back to software `x264enc` logs a warning instead of silently encoding 1440p+ on the CPU.

--- a/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/StreamViewModel.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/StreamViewModel.kt
@@ -47,6 +47,7 @@ class StreamViewModel(
     private val playerHolder = PlayerHolder(context, prefs)
     private var inputDispatcher: InputDispatcher? = null
     private var sessionToken: String? = null
+    private var lastIdrAtMs = 0L
 
     private val _state = MutableStateFlow(
         StreamState(
@@ -81,6 +82,9 @@ class StreamViewModel(
         viewModelScope.launch {
             playerHolder.event.collect { ev ->
                 _state.value = _state.value.copy(event = ev)
+                if (ev is StreamEvent.Error) {
+                    requestIdr()
+                }
             }
         }
         viewModelScope.launch {
@@ -135,6 +139,13 @@ class StreamViewModel(
                 }
             }
         }
+    }
+
+    private fun requestIdr() {
+        val now = android.os.SystemClock.elapsedRealtime()
+        if (now - lastIdrAtMs < 250L) return
+        lastIdrAtMs = now
+        ensureInput().control("idr")
     }
 
     fun ensureInput(): InputDispatcher {

--- a/clients/web/app.js
+++ b/clients/web/app.js
@@ -995,6 +995,7 @@ function startStream() {
 
     mpegtsPlayer.on(mpegts.Events.ERROR, (errorType, errorDetail, errorInfo) => {
         console.error("mpegts error:", errorType, errorDetail, errorInfo);
+        sendHostAction("idr");
         if (errorDetail === "NetworkError" && !authToken && tokenRow) {
             tokenRow.classList.remove("hidden");
         }

--- a/crates/orbiscreen-daemon/src/main.rs
+++ b/crates/orbiscreen-daemon/src/main.rs
@@ -1918,6 +1918,13 @@ async fn run_start(
     };
     let mut encoded_rx = encoder.subscribe().ok_or("encoder returned no rx")?;
     let encoder = Arc::new(encoder);
+    let (idr_tx, mut idr_rx) = mpsc::channel::<()>(8);
+    let encoder_for_idr = Arc::clone(&encoder);
+    tokio::spawn(async move {
+        while idr_rx.recv().await.is_some() {
+            encoder_for_idr.request_keyframe();
+        }
+    });
 
     let stats = std::sync::Arc::new(Stats::default());
 
@@ -2294,6 +2301,7 @@ async fn run_start(
         spec.refresh_rate_hz,
         encoder_name,
         shutdown_rx.clone(),
+        Some(idr_tx),
     ));
 
     tokio::select! {

--- a/crates/orbiscreen-encode/src/lib.rs
+++ b/crates/orbiscreen-encode/src/lib.rs
@@ -30,9 +30,17 @@ impl EncoderKind {
 
     pub fn gst_element(self) -> &'static str {
         match self {
-            Self::Auto | Self::Nvenc => "nvh264enc",
-            Self::Vaapi => "vaapih264enc",
-            Self::X264 => "x264enc",
+            Self::Auto => "nvh264enc",
+            other => other.gst_candidates()[0],
+        }
+    }
+
+    fn gst_candidates(self) -> &'static [&'static str] {
+        match self {
+            Self::Auto => Self::Nvenc.gst_candidates(),
+            Self::Nvenc => &["nvh264enc", "nvcudah264enc", "nvautogpuh264enc"],
+            Self::Vaapi => &["vah264enc", "vaapih264enc"],
+            Self::X264 => &["x264enc"],
         }
     }
 }
@@ -81,8 +89,20 @@ pub fn init() -> Result<(), EncodeError> {
     gstreamer::init().map_err(|e| EncodeError::Init(e.to_string()))
 }
 
-fn detect_available(preferred: EncoderKind) -> EncoderKind {
-    let registry = gstreamer::Registry::get();
+fn element_available(name: &str) -> bool {
+    gstreamer::Registry::get()
+        .find_feature(name, gstreamer::ElementFactory::static_type())
+        .is_some()
+}
+
+fn first_available_element(kind: EncoderKind) -> Option<&'static str> {
+    kind.gst_candidates()
+        .iter()
+        .copied()
+        .find(|name| element_available(name))
+}
+
+fn detect_available(preferred: EncoderKind) -> (EncoderKind, &'static str) {
     let search_order = match preferred {
         EncoderKind::Auto | EncoderKind::Nvenc => {
             [EncoderKind::Nvenc, EncoderKind::Vaapi, EncoderKind::X264]
@@ -91,15 +111,17 @@ fn detect_available(preferred: EncoderKind) -> EncoderKind {
         EncoderKind::X264 => [EncoderKind::X264, EncoderKind::Nvenc, EncoderKind::Vaapi],
     };
     for kind in search_order {
-        if registry
-            .find_feature(kind.gst_element(), gstreamer::ElementFactory::static_type())
-            .is_some()
-        {
-            return kind;
+        if let Some(element) = first_available_element(kind) {
+            if kind == EncoderKind::X264 && preferred != EncoderKind::X264 {
+                warn!(
+                    "hardware H.264 encoder not found (tried nvh264enc, nvcudah264enc, vah264enc, vaapih264enc); falling back to software x264 — expect high encode latency at 1440p+"
+                );
+            }
+            return (kind, element);
         }
     }
     warn!("no H.264 encoder found; pipeline construction will fail");
-    EncoderKind::X264
+    (EncoderKind::X264, "x264enc")
 }
 
 fn make_element(name: &str) -> Result<gstreamer::Element, EncodeError> {
@@ -135,9 +157,8 @@ impl Encoder {
     #[instrument(skip_all, fields(width = params.width, height = params.height))]
     pub fn new(params: EncodeParams) -> Result<Self, EncodeError> {
         init()?;
-        let kind = detect_available(params.kind);
-        let encoder_el = kind.gst_element();
-        info!(?kind, "Using GStreamer encoder");
+        let (kind, encoder_el) = detect_available(params.kind);
+        info!(?kind, element = encoder_el, "Using GStreamer encoder");
         let encoder = make_element(encoder_el)?;
 
         let appsrc = ElementFactory::make("appsrc")
@@ -223,6 +244,18 @@ impl Encoder {
             }
             if encoder.find_property("keyframe-period").is_some() {
                 encoder.set_property_from_str("keyframe-period", "60");
+            }
+            if encoder.find_property("key-int-max").is_some() {
+                encoder.set_property_from_str("key-int-max", "60");
+            }
+            if encoder.find_property("b-frames").is_some() {
+                encoder.set_property_from_str("b-frames", "0");
+            }
+            if encoder.find_property("target-usage").is_some() {
+                encoder.set_property_from_str("target-usage", "7");
+            }
+            if encoder.find_property("ref-frames").is_some() {
+                encoder.set_property_from_str("ref-frames", "1");
             }
         }
         if kind == EncoderKind::X264 {
@@ -441,7 +474,11 @@ mod tests {
     fn gst_element_names_are_stable() {
         assert_eq!(EncoderKind::X264.gst_element(), "x264enc");
         assert_eq!(EncoderKind::Nvenc.gst_element(), "nvh264enc");
-        assert_eq!(EncoderKind::Vaapi.gst_element(), "vaapih264enc");
+        assert_eq!(EncoderKind::Vaapi.gst_element(), "vah264enc");
+        assert!(EncoderKind::Vaapi
+            .gst_candidates()
+            .contains(&"vaapih264enc"));
+        assert!(EncoderKind::Nvenc.gst_candidates().contains(&"nvh264enc"));
     }
 
     #[test]
@@ -462,11 +499,25 @@ mod tests {
     #[test]
     fn detect_available_returns_a_known_kind() {
         init().unwrap();
-        let kind = detect_available(EncoderKind::X264);
+        let (kind, element) = detect_available(EncoderKind::X264);
         assert!(matches!(
             kind,
             EncoderKind::X264 | EncoderKind::Vaapi | EncoderKind::Nvenc,
         ));
+        assert!(!element.is_empty());
+    }
+
+    #[test]
+    fn auto_prefers_hardware_when_va_or_nvenc_is_registered() {
+        init().unwrap();
+        let (kind, element) = detect_available(EncoderKind::Auto);
+        if element_available("vah264enc")
+            || element_available("vaapih264enc")
+            || element_available("nvh264enc")
+        {
+            assert_ne!(kind, EncoderKind::X264, "auto selected software {element}");
+            assert_ne!(element, "x264enc");
+        }
     }
 
     #[test]

--- a/crates/orbiscreen-encode/src/lib.rs
+++ b/crates/orbiscreen-encode/src/lib.rs
@@ -1,6 +1,9 @@
 // Orbiscreen - lib.rs (GPL-3.0-or-later)
 // https://github.com/shadow-x78/orbiscreen
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use gstreamer::glib;
 use gstreamer::prelude::*;
 use gstreamer::{ClockTime, ElementFactory, Pipeline};
 use gstreamer_app::{AppSink, AppSinkCallbacks, AppSrc};
@@ -130,6 +133,58 @@ fn make_element(name: &str) -> Result<gstreamer::Element, EncodeError> {
         .map_err(|e| EncodeError::Pipeline(format!("{name}: {e}")))
 }
 
+fn set_str_if_present(el: &gstreamer::Element, name: &str, value: &str) {
+    if el.find_property(name).is_some() {
+        el.set_property_from_str(name, value);
+    }
+}
+
+fn max_u32_property(el: &gstreamer::Element, name: &str) -> Option<u32> {
+    let spec = el.find_property(name)?;
+    spec.downcast_ref::<glib::ParamSpecUInt>()
+        .map(|p| p.maximum())
+        .or_else(|| {
+            spec.downcast_ref::<glib::ParamSpecInt>()
+                .map(|p| p.maximum() as u32)
+        })
+}
+
+fn configure_infinite_gop(encoder: &gstreamer::Element) {
+    set_str_if_present(encoder, "intra-refresh", "true");
+    if let Some(max) = max_u32_property(encoder, "key-int-max") {
+        let value = if max == 0 { 1024 } else { max };
+        encoder.set_property_from_str("key-int-max", &value.to_string());
+    }
+    if encoder.find_property("gop-size").is_some() {
+        if let Some(spec) = encoder.find_property("gop-size") {
+            if spec.downcast_ref::<glib::ParamSpecInt>().is_some() {
+                encoder.set_property_from_str("gop-size", "-1");
+            } else if let Some(max) = max_u32_property(encoder, "gop-size") {
+                let value = if max == 0 { 1024 } else { max };
+                encoder.set_property_from_str("gop-size", &value.to_string());
+            }
+        }
+    }
+    if let Some(max) = max_u32_property(encoder, "keyframe-period") {
+        let value = if max == 0 { 1024 } else { max };
+        encoder.set_property_from_str("keyframe-period", &value.to_string());
+    }
+    if encoder
+        .find_property("min-force-key-unit-interval")
+        .is_some()
+    {
+        encoder.set_property("min-force-key-unit-interval", 100_000_000u64);
+    }
+}
+
+fn force_key_unit_event() -> gstreamer::Event {
+    let structure = gstreamer::Structure::builder("GstForceKeyUnit")
+        .field("all-headers", true)
+        .field("count", 0u32)
+        .build();
+    gstreamer::event::CustomUpstream::new(structure)
+}
+
 #[derive(Debug, Clone)]
 pub struct EncodedChunk {
     pub bytes: Vec<u8>,
@@ -141,10 +196,12 @@ pub struct EncodedChunk {
 pub struct Encoder {
     pipeline: Pipeline,
     appsrc: AppSrc,
+    encoder: gstreamer::Element,
     kind: EncoderKind,
     width: u32,
     height: u32,
     rx: Option<mpsc::Receiver<EncodedChunk>>,
+    last_key_request_ns: AtomicU64,
 }
 
 impl Drop for Encoder {
@@ -231,9 +288,6 @@ impl Encoder {
             if encoder.find_property("repeat-sequence-header").is_some() {
                 encoder.set_property_from_str("repeat-sequence-header", "true");
             }
-            if encoder.find_property("gop-size").is_some() {
-                encoder.set_property_from_str("gop-size", "60");
-            }
             if encoder.find_property("b-frames").is_some() {
                 encoder.set_property_from_str("b-frames", "0");
             }
@@ -241,12 +295,6 @@ impl Encoder {
         if kind == EncoderKind::Vaapi {
             if encoder.find_property("rate-control").is_some() {
                 encoder.set_property_from_str("rate-control", "cbr");
-            }
-            if encoder.find_property("keyframe-period").is_some() {
-                encoder.set_property_from_str("keyframe-period", "60");
-            }
-            if encoder.find_property("key-int-max").is_some() {
-                encoder.set_property_from_str("key-int-max", "60");
             }
             if encoder.find_property("b-frames").is_some() {
                 encoder.set_property_from_str("b-frames", "0");
@@ -270,9 +318,6 @@ impl Encoder {
             if encoder.find_property("repeat-headers").is_some() {
                 encoder.set_property_from_str("repeat-headers", "true");
             }
-            if encoder.find_property("key-int-max").is_some() {
-                encoder.set_property_from_str("key-int-max", "60");
-            }
             if encoder.find_property("b-adapt").is_some() {
                 encoder.set_property_from_str("b-adapt", "0");
             }
@@ -280,6 +325,7 @@ impl Encoder {
                 encoder.set_property_from_str("bframes", "0");
             }
         }
+        configure_infinite_gop(&encoder);
 
         let h264parse = make_element("h264parse")?;
         h264parse.set_property_from_str("config-interval", "1");
@@ -359,11 +405,34 @@ impl Encoder {
         Ok(Self {
             pipeline,
             appsrc,
+            encoder,
             kind,
             width: params.width,
             height: params.height,
             rx: Some(rx),
+            last_key_request_ns: AtomicU64::new(0),
         })
+    }
+
+    pub fn request_keyframe(&self) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0);
+        let prev = self.last_key_request_ns.load(Ordering::Relaxed);
+        if now.saturating_sub(prev) < 200_000_000 {
+            return;
+        }
+        self.last_key_request_ns.store(now, Ordering::Relaxed);
+        let Some(pad) = self.encoder.static_pad("src") else {
+            warn!("encoder has no src pad; cannot request IDR");
+            return;
+        };
+        if pad.send_event(force_key_unit_event()) {
+            info!(kind = ?self.kind, "requested IDR from encoder");
+        } else {
+            warn!(kind = ?self.kind, "encoder rejected force-key-unit");
+        }
     }
 
     pub fn subscribe(&mut self) -> Option<mpsc::Receiver<EncodedChunk>> {
@@ -524,5 +593,30 @@ mod tests {
     fn frame_duration_ns_matches_framerate() {
         assert_eq!(Encoder::frame_duration_ns(60), 16_666_666);
         assert_eq!(Encoder::frame_duration_ns(30), 33_333_333);
+    }
+
+    #[test]
+    fn infinite_gop_uses_property_maximum() {
+        init().unwrap();
+        let encoder = make_element("x264enc").unwrap();
+        configure_infinite_gop(&encoder);
+        assert!(encoder.property::<bool>("intra-refresh"));
+        assert!(encoder.property::<u32>("key-int-max") > 60);
+    }
+
+    #[test]
+    fn request_keyframe_is_safe_before_playing() {
+        init().unwrap();
+        let encoder = Encoder::new(EncodeParams {
+            kind: EncoderKind::X264,
+            bitrate_kbps: 1000,
+            width: 64,
+            height: 64,
+            framerate: 30,
+        });
+        if let Ok(encoder) = encoder {
+            encoder.request_keyframe();
+            encoder.stop();
+        }
     }
 }

--- a/crates/orbiscreen-transport/src/lib.rs
+++ b/crates/orbiscreen-transport/src/lib.rs
@@ -174,6 +174,7 @@ impl Transport {
         refresh_hz: u32,
         encoder_kind: &'static str,
         mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+        idr_tx: Option<mpsc::Sender<()>>,
     ) -> Result<(), TransportError> {
         let input_tx = self.input_tx;
         let (video_tx, _video_rx) = tokio::sync::broadcast::channel::<H264Packet>(64);
@@ -189,6 +190,7 @@ impl Transport {
             encoder_kind,
             version: env!("CARGO_PKG_VERSION"),
             started: std::time::Instant::now(),
+            idr_tx,
         };
         let app = build_router(state.clone());
         let listener = TcpListener::bind(("0.0.0.0", self.cfg.signaling_port))
@@ -271,6 +273,7 @@ struct AppState {
     encoder_kind: &'static str,
     version: &'static str,
     started: std::time::Instant,
+    idr_tx: Option<mpsc::Sender<()>>,
 }
 
 fn build_router(state: AppState) -> Router {
@@ -470,6 +473,12 @@ fn inject_ctrl_alt_del(tx: &mpsc::Sender<IncomingInput>) {
     }
 }
 
+fn request_idr(state: &AppState) {
+    if let Some(tx) = &state.idr_tx {
+        let _ = tx.try_send(());
+    }
+}
+
 async fn api_control(
     State(state): State<AppState>,
     Json(payload): Json<serde_json::Value>,
@@ -514,6 +523,11 @@ async fn api_control(
         Some("ctrl_alt_del") => {
             inject_ctrl_alt_del(&state.input_tx);
             info!("host control: Ctrl+Alt+Del injected");
+            (StatusCode::OK, Json(serde_json::json!({"ok": true})))
+        }
+        Some("idr") | Some("keyframe") => {
+            request_idr(&state);
+            info!("host control: IDR requested");
             (StatusCode::OK, Json(serde_json::json!({"ok": true})))
         }
         Some("set_resolution") => {
@@ -728,8 +742,10 @@ async fn stream_handler(State(state): State<AppState>) -> axum::response::Respon
     }
 
     state.stats.client_started();
+    request_idr(&state);
     let appsrc_clone = appsrc.clone();
     let stats = state.stats.clone();
+    let idr_tx = state.idr_tx.clone();
 
     struct PipelineGuard(gstreamer::Pipeline);
     impl Drop for PipelineGuard {
@@ -757,6 +773,9 @@ async fn stream_handler(State(state): State<AppState>) -> axum::response::Respon
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                     debug!("stream client lagged {n} packets; waiting for keyframe");
                     wait_keyframe = true;
+                    if let Some(tx) = &idr_tx {
+                        let _ = tx.try_send(());
+                    }
                     continue;
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => break,


### PR DESCRIPTION
This is another latency-improvement PR. I will follow with more of those.

**Depends on #71.** Latency stack: #70 → #71 → #72. Merge after #71 (this branch includes #70 and #71, then infinite GOP + on-demand IDR).

### What does this PR do?

Stops emitting a keyframe every 60 frames. GOP length uses the encoder maximum (`key-int-max` / `gop-size`); `x264enc` also enables periodic intra-refresh so P-frames stay small.

Recovery is on demand: `POST /api/control` with `{"action":"idr"}`. A new `/stream` client and a lagged muxer request the same. The encoder src pad gets an upstream `GstForceKeyUnit` (all headers), debounced to 200 ms. Android decoder errors and web `mpegts` errors call that endpoint.

### Why?

Sunshine uses infinite GOP + intra-refresh and asks for one IDR when the client loses a frame. Orbiscreen waited up to 1 s for the next scheduled keyframe (`gop-size` / `key-int-max` = 60). Frequent IDRs waste Wi-Fi; a 1 s GOP makes join and loss recovery slow.

See the `[Unreleased]` entry in `CHANGELOG.md`.

### How was it tested?

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (changed crates: `orbiscreen-encode`, `orbiscreen-transport`, `orbiscreen-daemon`; GTK excluded)
- [x] `cargo test --workspace` (ran `orbiscreen-encode`, including `infinite_gop_uses_property_maximum` and `request_keyframe_is_safe_before_playing`)
- [x] Manual smoke test on: KDE Plasma Wayland + Samsung Galaxy Tab S5e (SM-T725). Local daemon `target/debug/orbiscreen start`; debug APK over USB. `/health` reported `encoder=vaapi`. Tablet Connect to `tower8` streamed the virtual display. Joining `/stream` requested an IDR. `POST /api/control {"action":"idr"}` returned `{"ok":true}` and logged `requested IDR from encoder kind=Vaapi`. The picture stayed clean (`active_clients=1`).

### Checklist

- [x] No new warnings introduced.
- [x] File headers match Orbiscreen style (`// Orbiscreen - <module> (GPL-3.0-or-later)` + GitHub URL).
- [x] `CHANGELOG.md` updated.