### PR TITLE
orbiscreen | feat: UDP Annex-B transport with DPLPMTUD and KWin virtual display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### ⚡ Performance & Low Latency
+- **UDP Annex-B Video Transport (`orbiscreen-transport`, Android Client)**:
+  - Second path beside HTTP MPEG-TS: H.264 access units over UDP (`signaling_port + 1`, advertised as `udp_port` on `/api/info`).
+  - Hello carries the session token; ping/pong measures RTT; IDR requests reuse the existing encoder force-key-unit path.
+  - Android prefers UDP and decodes with MediaCodec onto a Surface (no ExoPlayer / MPEG-TS). HTTP `/stream` remains for the web client and as fallback (including USB/AOA `127.0.0.1`, where raw UDP cannot be reversed).
+  - Reassemble access units in linear time, enlarge socket buffers, and hold P-frames after a lost fragment until the next IDR so a dropped UDP packet cannot leave the decoder permanently garbled.
+  - Per-client DPLPMTUD: host probes upward from a safe baseline (1200) with padded UDP datagrams; the Android client ACKs the received size. Video fragments follow the confirmed datagram. Probe and video datagrams set `IP_PMTUDISC_PROBE`. Acks that do not match the in-flight probe id are ignored after the search completes. `ORBISCREEN_UDP_MAX_DATAGRAM` caps the search; `ORBISCREEN_UDP_DROP_ABOVE` pretends larger packets were lost (test hook). `ORBISCREEN_UDP_LOSS_PCT` randomly drops outgoing datagrams (test hook).
+  - UDP hello waits out the handshake window so a PMTU probe arriving before Hello-Ack does not abort the session. A host-liveness watchdog ends the UDP session if no packet arrives. The UDP surface letterboxes to the same content rect as touch mapping. The stream menu shows send-to-assemble delay as `delay Nms` (2–4 ms on a 2560×1600 VA-API Wi-Fi path; HTTP ExoPlayer still targets a 24 ms live offset).
+
+### 🖥 Virtual Display
+- **KWin Virtual Output & Direct Touch (`orbiscreen-daemon`, `orbiscreen-capture`, `orbiscreen-input`)**:
+  - Create `Virtual-ORBISCREEN`, then `Virtual-ORBISCREEN-{pid}` when the unsuffixed name is already taken. Clear a disabled KWin output config before creating the stream. Bind mouse, touchscreen, and tablet to the connector name the stream actually accepted.
+  - Bind only when this session owns an enabled Orbiscreen virtual output (`outputName` + `outputUuid`, `mapToWorkspace = false`).
+  - Direct Touch writes evdev type-B slots on the virtual touchscreen and lifts the pen before the first finger.
+  - After the last HTTP/UDP client disconnects, lift `BTN_TOOL_PEN` and close the KWin virtual output so it leaves the layout. The next client recreates the stream (retrying unpark while still present), rebinds input to the new connector, and requests an IDR. A parked capture waits quietly instead of warning every frame.
+
 ## [v0.24.0] - 2026-09-07
 
 Harmonize UI/UX design and Catppuccin Mocha palette between Android and Web clients, eliminate redundant Blank Display action, strengthen Web CSP headers, sanitize input coordinates against non-finite values, enforce strict codebase comment standards, and purge dead build artifacts.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,6 +1403,7 @@ dependencies = [
  "gstreamer",
  "gstreamer-app",
  "hostname",
+ "libc",
  "mdns-sd",
  "orbiscreen-encode",
  "orbiscreen-input",

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ With hardware encoding enabled (NVIDIA NVENC or Intel/AMD VA-API on Linux, and M
 | Document | Description |
 |----------|-------------|
 | [ARCHITECTURE.md](docs/ARCHITECTURE.md) | System topology, frame pipeline &amp; D-Bus architecture |
+| [UDP_TRANSPORT.md](docs/UDP_TRANSPORT.md) | UDP Annex-B video path, packet types, DPLPMTUD &amp; test hooks |
 | [DE_SUPPORT.md](docs/DE_SUPPORT.md) | Per-desktop support matrix, capture plans &amp; troubleshooting |
 | [PACKAGING.md](docs/PACKAGING.md) | Multi-distro packaging specs (.deb, .rpm, AppImage) |
 | [DBUS_SPEC.md](docs/DBUS_SPEC.md) | D-Bus Session Bus IPC interface specifications |

--- a/clients/android/app/src/main/java/com/orbiscreen/android/MainActivity.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/MainActivity.kt
@@ -132,7 +132,10 @@ private fun App(prefs: PrefsStore) {
             PrefsStore.ThemePref.Dark -> ThemeMode.Dark
         },
     ) {
-        OrbiNav(prefs)
+        val activity = context as? android.app.Activity
+        val startHost = activity?.intent?.getStringExtra("host")
+        val startPort = activity?.intent?.getIntExtra("port", 8788) ?: 8788
+        OrbiNav(prefs, startHost = startHost, startPort = startPort)
         startupUpdate?.let { release ->
             UpdateDialog(
                 release = release,

--- a/clients/android/app/src/main/java/com/orbiscreen/android/net/HostApi.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/net/HostApi.kt
@@ -34,6 +34,7 @@ class HostApi {
         val refreshHz: Int = 60,
         val encoder: String = "unknown",
         val version: String = "?",
+        val udpPort: Int = 0,
     )
 
     suspend fun token(host: String, port: Int): String? = withContext(Dispatchers.IO) {
@@ -71,6 +72,7 @@ class HostApi {
                         refreshHz = obj.optInt("refresh_hz", 60),
                         encoder = obj.optString("encoder", "unknown"),
                         version = obj.optString("version", "?"),
+                        udpPort = obj.optInt("udp_port", 0),
                     )
                 }
             } catch (e: Exception) {

--- a/clients/android/app/src/main/java/com/orbiscreen/android/player/PlayerHolder.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/player/PlayerHolder.kt
@@ -72,6 +72,8 @@ class PlayerHolder(
 
     private val _player = MutableStateFlow<ExoPlayer?>(null)
     val player: StateFlow<ExoPlayer?> get() = _player
+    private val _udp = MutableStateFlow<UdpPlayer?>(null)
+    val udpPlayer: StateFlow<UdpPlayer?> get() = _udp
 
     private var reconnectJob: Job? = null
     private var reconnectDelayMs = 1_000L
@@ -118,6 +120,26 @@ class PlayerHolder(
         val uri = StreamUrl.build(host, port, token)
         android.util.Log.i("OrbiPlayer", "connecting to stream: $uri")
         _event.value = StreamEvent.Connecting(uri)
+
+        val info = try {
+            com.orbiscreen.android.net.HostApi().info(host, port)
+        } catch (_: Exception) {
+            null
+        }
+        if (info != null && info.udpPort in 1..65535 && host != "127.0.0.1" && host != "localhost") {
+            val udp = UdpPlayer()
+            val started = kotlinx.coroutines.withContext(Dispatchers.IO) {
+                udp.start(host, info.udpPort, token, info.width, info.height)
+            }
+            if (started) {
+                _udp.value = udp
+                _player.value = null
+                scope.launch {
+                    udp.event.collect { ev -> _event.value = ev }
+                }
+                return null
+            }
+        }
 
         val player = try {
             val httpFactory = OkHttpDataSource.Factory(okHttp)
@@ -318,6 +340,8 @@ class PlayerHolder(
     }
 
     private fun releaseInternal() {
+        _udp.value?.stop()
+        _udp.value = null
         _player.value?.release()
         _player.value = null
         _event.value = StreamEvent.Idle

--- a/clients/android/app/src/main/java/com/orbiscreen/android/player/UdpPlayer.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/player/UdpPlayer.kt
@@ -1,0 +1,494 @@
+// Orbiscreen - UdpPlayer.kt (GPL-3.0-or-later)
+// https://github.com/shadow-x78/orbiscreen
+
+package com.orbiscreen.android.player
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.net.Uri
+import android.os.Build
+import android.os.Looper
+import android.util.Log
+import android.view.Surface
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import java.net.SocketTimeoutException
+import java.nio.ByteBuffer
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+private const val TAG = "Orbi.Udp"
+private const val HOST_TIMEOUT_MS = 4_000L
+private const val HELLO_WINDOW_MS = 1_500L
+private const val TYPE_VIDEO: Byte = 1
+private const val TYPE_HELLO: Byte = 2
+private const val TYPE_HELLO_ACK: Byte = 3
+private const val TYPE_PING: Byte = 4
+private const val TYPE_PONG: Byte = 5
+private const val TYPE_IDR: Byte = 6
+private const val TYPE_PROBE: Byte = 7
+private const val TYPE_PROBE_ACK: Byte = 8
+private const val TYPE_PMTU: Byte = 9
+private const val RECV_BUF: Int = 4096
+
+enum class HandshakeAction { Ack, Control, Ignore }
+
+class UdpPlayer {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val _event = MutableStateFlow<StreamEvent>(StreamEvent.Idle)
+    val event: StateFlow<StreamEvent> get() = _event
+    private val _latencyMs = MutableStateFlow(-1)
+    val latencyMs: StateFlow<Int> get() = _latencyMs
+    private val _rttMs = MutableStateFlow(-1)
+    val rttMs: StateFlow<Int> get() = _rttMs
+
+    private var socket: DatagramSocket? = null
+    private var recvJob: Job? = null
+    private var pingJob: Job? = null
+    private var watchdogJob: Job? = null
+    private var codec: MediaCodec? = null
+    @Volatile private var surface: Surface? = null
+    @Volatile private var running = false
+    private val pending = ConcurrentHashMap<Int, Array<ByteArray?>>()
+    private var sps: ByteArray? = null
+    private var pps: ByteArray? = null
+    private var configured = false
+    private var waitKey = true
+    private var lastEmittedSeq = -1
+    private val lastIdr = AtomicLong(0)
+    private val lastHeardMs = AtomicLong(0)
+    private var hostAddr: InetAddress? = null
+    private var hostPort: Int = 0
+    private var clockOffsetNs: Long = 0
+    var width: Int = 1920
+    var height: Int = 1080
+
+    fun attachSurface(s: Surface) {
+        val same = surface == s && configured && codec != null
+        surface = s
+        if (same) return
+        configured = false
+        waitKey = true
+        requestIdr()
+    }
+
+    fun detachSurface() {
+        surface = null
+        releaseCodec()
+    }
+
+    fun start(host: String, port: Int, token: String, width: Int, height: Int): Boolean {
+        stop()
+        this.width = width
+        this.height = height
+        return try {
+            val addr = InetAddress.getByName(host)
+            hostAddr = addr
+            hostPort = port
+            val sock = DatagramSocket()
+            sock.receiveBufferSize = 2 * 1024 * 1024
+            sock.sendBufferSize = 256 * 1024
+            sock.soTimeout = 200
+            socket = sock
+            running = true
+            _event.value = StreamEvent.Connecting(Uri.parse("udp://$host:$port"))
+            sendRaw(encodeHello(token))
+            val buf = ByteArray(RECV_BUF)
+            val pkt = DatagramPacket(buf, buf.size)
+            val deadline = System.currentTimeMillis() + HELLO_WINDOW_MS
+            var acked = false
+            while (!acked && System.currentTimeMillis() < deadline) {
+                try {
+                    sock.receive(pkt)
+                    val data = buf.copyOf(pkt.length)
+                    when (handshakeAction(data)) {
+                        HandshakeAction.Ack -> {
+                            acked = true
+                            lastHeardMs.set(System.currentTimeMillis())
+                        }
+                        HandshakeAction.Control -> handle(data)
+                        HandshakeAction.Ignore -> {}
+                    }
+                } catch (_: SocketTimeoutException) {
+                }
+            }
+            if (!acked) {
+                Log.w(TAG, "no hello-ack")
+                stop()
+                return false
+            }
+            sock.soTimeout = 0
+            lastHeardMs.set(System.currentTimeMillis())
+            recvJob = scope.launch { recvLoop() }
+            pingJob = scope.launch { pingLoop() }
+            watchdogJob = scope.launch { watchdogLoop() }
+            sendRaw(encodeCtrl(TYPE_IDR))
+            _event.value = StreamEvent.Buffering
+            Log.i(TAG, "UDP session up $host:$port")
+            true
+        } catch (e: Exception) {
+            Log.w(TAG, "UDP start failed: ${e.message}")
+            stop()
+            false
+        }
+    }
+
+    fun stop() {
+        teardown(StreamEvent.Idle)
+    }
+
+    private fun fail(reason: String) {
+        teardown(StreamEvent.Disconnected(reason))
+    }
+
+    private fun teardown(event: StreamEvent) {
+        val wasRunning = running
+        running = false
+        recvJob?.cancel()
+        pingJob?.cancel()
+        watchdogJob?.cancel()
+        recvJob = null
+        pingJob = null
+        watchdogJob = null
+        try { socket?.close() } catch (_: Exception) {}
+        socket = null
+        releaseCodec()
+        pending.clear()
+        sps = null
+        pps = null
+        configured = false
+        waitKey = true
+        lastEmittedSeq = -1
+        if (wasRunning || event !is StreamEvent.Idle) {
+            _event.value = event
+        }
+    }
+
+    private suspend fun watchdogLoop() {
+        while (scope.isActive && running) {
+            delay(500)
+            if (System.currentTimeMillis() - lastHeardMs.get() > HOST_TIMEOUT_MS) {
+                Log.w(TAG, "host timed out")
+                fail("UDP host timed out")
+                return
+            }
+        }
+    }
+
+    private fun releaseCodec() {
+        try { codec?.stop() } catch (_: Exception) {}
+        try { codec?.release() } catch (_: Exception) {}
+        codec = null
+        configured = false
+    }
+
+    private suspend fun pingLoop() {
+        while (scope.isActive && running) {
+            sendRaw(encodePing(System.currentTimeMillis() * 1_000_000L))
+            delay(500)
+        }
+    }
+
+    private fun recvLoop() {
+        val buf = ByteArray(RECV_BUF)
+        val pkt = DatagramPacket(buf, buf.size)
+        while (running) {
+            try {
+                socket?.receive(pkt) ?: break
+                handle(buf.copyOf(pkt.length))
+            } catch (e: Exception) {
+                if (running) Log.w(TAG, "recv: ${e.message}")
+                break
+            }
+        }
+        if (running) fail("UDP socket closed")
+    }
+
+    private fun handle(data: ByteArray) {
+        if (data.size < 5 || data[0] != 'O'.code.toByte() || data[1] != 'R'.code.toByte()
+            || data[2] != 'B'.code.toByte() || data[3] != '1'.code.toByte()
+        ) return
+        lastHeardMs.set(System.currentTimeMillis())
+        when (data[4]) {
+            TYPE_VIDEO -> handleVideo(data)
+            TYPE_PONG -> {
+                if (data.size < 21) return
+                val t0 = le64(data, 5)
+                val hostNs = le64(data, 13)
+                val now = System.currentTimeMillis() * 1_000_000L
+                val rtt = ((now - t0) / 1_000_000L).toInt().coerceAtLeast(0)
+                _rttMs.value = rtt
+                clockOffsetNs = hostNs + (now - t0) / 2 - now
+            }
+            TYPE_PROBE -> {
+                if (data.size < 7) return
+                val id = le16(data, 5)
+                Log.i(TAG, "PMTU probe id=$id size=${data.size}")
+                sendRaw(encodeProbeAck(id, data.size))
+            }
+            TYPE_PMTU -> {
+                if (data.size < 7) return
+                Log.i(TAG, "PMTU confirmed datagram=${le16(data, 5)}")
+            }
+            TYPE_HELLO_ACK -> {}
+            else -> {}
+        }
+    }
+
+    private fun handleVideo(data: ByteArray) {
+        if (data.size < 28) return
+        val key = data[5].toInt() != 0
+        val seq = le16(data, 6)
+        val frag = le16(data, 8)
+        val frags = le16(data, 10)
+        val sentNs = le64(data, 20)
+        val payload = data.copyOfRange(28, data.size)
+        if (frags <= 0 || frag >= frags) return
+        dropStale(seq)
+        val slots = pending.getOrPut(seq) { arrayOfNulls(frags) }
+        if (slots.size != frags) {
+            pending[seq] = arrayOfNulls<ByteArray?>(frags).also { it[frag] = payload }
+            return
+        }
+        slots[frag] = payload
+        if (slots.any { it == null }) return
+        pending.remove(seq)
+        val au = assemble(slots)
+        val now = System.currentTimeMillis() * 1_000_000L
+        val glass = ((now + clockOffsetNs - sentNs) / 1_000_000L).toInt()
+        if (glass in 0..5_000) _latencyMs.value = glass
+        val gap = lastEmittedSeq >= 0 && seqDelta(seq, lastEmittedSeq) != 1
+        lastEmittedSeq = seq
+        if (gap && !key) {
+            waitKey = true
+            requestIdr()
+            return
+        }
+        if (waitKey && !key) {
+            requestIdr()
+            return
+        }
+        if (key) {
+            extractSpsPps(au)
+            waitKey = false
+            if (_event.value !is StreamEvent.Playing) _event.value = StreamEvent.Playing
+        }
+        feedCodec(au, key)
+    }
+
+    private fun dropStale(seq: Int) {
+        if (pending.size < 4) return
+        val stale = pending.keys.filter { seqDelta(seq, it) in 2..32767 }
+        if (stale.isEmpty()) return
+        for (s in stale) pending.remove(s)
+        waitKey = true
+        requestIdr()
+    }
+
+    private fun extractSpsPps(au: ByteArray) {
+        var i = 0
+        while (i + 4 < au.size) {
+            val sc = startCodeLen(au, i) ?: break
+            val nalStart = i + sc
+            var next = nalStart
+            while (next < au.size) {
+                val n = startCodeLen(au, next)
+                if (n != null && next > nalStart) break
+                next++
+            }
+            val nal = au.copyOfRange(nalStart, next.coerceAtMost(au.size))
+            if (nal.isNotEmpty()) {
+                when (nal[0].toInt() and 0x1F) {
+                    7 -> sps = withStartCode(nal)
+                    8 -> pps = withStartCode(nal)
+                }
+            }
+            i = next
+        }
+    }
+
+    private fun feedCodec(au: ByteArray, key: Boolean) {
+        val surf = surface ?: return
+        val sps0 = sps
+        val pps0 = pps
+        if (!configured) {
+            if (sps0 == null || pps0 == null) {
+                requestIdr()
+                return
+            }
+            try {
+                releaseCodec()
+                val format = MediaFormat.createVideoFormat(MediaFormat.MIMETYPE_VIDEO_AVC, width, height)
+                format.setByteBuffer("csd-0", ByteBuffer.wrap(sps0))
+                format.setByteBuffer("csd-1", ByteBuffer.wrap(pps0))
+                format.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, 4 * 1024 * 1024)
+                if (Build.VERSION.SDK_INT >= 30) {
+                    format.setInteger(MediaFormat.KEY_LOW_LATENCY, 1)
+                }
+                if (Build.VERSION.SDK_INT >= 23) {
+                    format.setInteger(MediaFormat.KEY_PRIORITY, 0)
+                    format.setInteger(MediaFormat.KEY_OPERATING_RATE, Short.MAX_VALUE.toInt())
+                }
+                val c = MediaCodec.createDecoderByType(MediaFormat.MIMETYPE_VIDEO_AVC)
+                c.configure(format, surf, null, 0)
+                c.start()
+                codec = c
+                configured = true
+                Log.i(TAG, "MediaCodec configured ${width}x${height}")
+            } catch (e: Exception) {
+                Log.w(TAG, "codec configure: ${e.message}")
+                requestIdr()
+                return
+            }
+        }
+        val c = codec ?: return
+        if (waitKey && !key) {
+            requestIdr()
+            return
+        }
+        try {
+            val inIx = c.dequeueInputBuffer(8_000)
+            if (inIx < 0) {
+                if (key) waitKey = true
+                return
+            }
+            val inBuf = c.getInputBuffer(inIx) ?: return
+            if (inBuf.remaining() < au.size) {
+                Log.w(TAG, "codec input ${inBuf.remaining()} < au ${au.size}")
+                c.queueInputBuffer(inIx, 0, 0, 0, 0)
+                waitKey = true
+                requestIdr()
+                return
+            }
+            inBuf.clear()
+            inBuf.put(au)
+            val flags = if (key) MediaCodec.BUFFER_FLAG_KEY_FRAME else 0
+            c.queueInputBuffer(inIx, 0, au.size, System.nanoTime() / 1000, flags)
+            val info = MediaCodec.BufferInfo()
+            var outIx = c.dequeueOutputBuffer(info, 0)
+            while (outIx >= 0) {
+                c.releaseOutputBuffer(outIx, true)
+                outIx = c.dequeueOutputBuffer(info, 0)
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "codec feed: ${e.message}")
+            configured = false
+            waitKey = true
+            requestIdr()
+        }
+    }
+
+    private fun requestIdr() {
+        val now = System.currentTimeMillis()
+        if (now - lastIdr.get() < 250) return
+        lastIdr.set(now)
+        sendRaw(encodeCtrl(TYPE_IDR))
+    }
+
+    private fun sendRaw(bytes: ByteArray) {
+        val addr = hostAddr ?: return
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            scope.launch { sendLocked(bytes, addr) }
+        } else {
+            sendLocked(bytes, addr)
+        }
+    }
+
+    @Synchronized
+    private fun sendLocked(bytes: ByteArray, addr: InetAddress) {
+        val sock = socket ?: return
+        try {
+            sock.send(DatagramPacket(bytes, bytes.size, addr, hostPort))
+        } catch (e: Exception) {
+            if (running) Log.w(TAG, "send ${e.javaClass.simpleName}: ${e.message}")
+        }
+    }
+
+    companion object {
+        fun handshakeAction(data: ByteArray): HandshakeAction {
+            if (data.size < 5 ||
+                data[0] != 'O'.code.toByte() ||
+                data[1] != 'R'.code.toByte() ||
+                data[2] != 'B'.code.toByte() ||
+                data[3] != '1'.code.toByte()
+            ) {
+                return HandshakeAction.Ignore
+            }
+            return when (data[4]) {
+                TYPE_HELLO_ACK -> HandshakeAction.Ack
+                TYPE_PROBE, TYPE_PONG, TYPE_PMTU, TYPE_VIDEO, TYPE_IDR -> HandshakeAction.Control
+                else -> HandshakeAction.Ignore
+            }
+        }
+
+        fun encodeHello(token: String): ByteArray {
+            val t = token.toByteArray(Charsets.UTF_8)
+            return byteArrayOf('O'.code.toByte(), 'R'.code.toByte(), 'B'.code.toByte(), '1'.code.toByte(), TYPE_HELLO) + t
+        }
+        fun encodeCtrl(type: Byte): ByteArray =
+            byteArrayOf('O'.code.toByte(), 'R'.code.toByte(), 'B'.code.toByte(), '1'.code.toByte(), type)
+        fun encodePing(t0: Long): ByteArray {
+            val b = ByteArray(13)
+            b[0] = 'O'.code.toByte(); b[1] = 'R'.code.toByte(); b[2] = 'B'.code.toByte(); b[3] = '1'.code.toByte()
+            b[4] = TYPE_PING
+            putLe64(b, 5, t0)
+            return b
+        }
+        fun encodeProbeAck(id: Int, recv: Int): ByteArray {
+            val b = ByteArray(9)
+            b[0] = 'O'.code.toByte(); b[1] = 'R'.code.toByte(); b[2] = 'B'.code.toByte(); b[3] = '1'.code.toByte()
+            b[4] = TYPE_PROBE_ACK
+            putLe16(b, 5, id)
+            putLe16(b, 7, recv)
+            return b
+        }
+        fun le16(d: ByteArray, o: Int): Int =
+            (d[o].toInt() and 0xFF) or ((d[o + 1].toInt() and 0xFF) shl 8)
+        fun le64(d: ByteArray, o: Int): Long {
+            var v = 0L
+            for (i in 0 until 8) v = v or ((d[o + i].toLong() and 0xFF) shl (8 * i))
+            return v
+        }
+        fun putLe16(d: ByteArray, o: Int, v: Int) {
+            d[o] = (v and 0xFF).toByte()
+            d[o + 1] = ((v ushr 8) and 0xFF).toByte()
+        }
+        fun putLe64(d: ByteArray, o: Int, v: Long) {
+            var x = v
+            for (i in 0 until 8) {
+                d[o + i] = (x and 0xFF).toByte()
+                x = x ushr 8
+            }
+        }
+        fun startCodeLen(d: ByteArray, i: Int): Int? {
+            if (i + 3 < d.size && d[i] == 0.toByte() && d[i + 1] == 0.toByte() && d[i + 2] == 1.toByte()) return 3
+            if (i + 4 < d.size && d[i] == 0.toByte() && d[i + 1] == 0.toByte() && d[i + 2] == 0.toByte() && d[i + 3] == 1.toByte()) return 4
+            return null
+        }
+        fun withStartCode(nal: ByteArray): ByteArray =
+            byteArrayOf(0, 0, 0, 1) + nal
+        fun seqDelta(cur: Int, prev: Int): Int = (cur - prev) and 0xFFFF
+        fun assemble(slots: Array<ByteArray?>): ByteArray {
+            var total = 0
+            for (p in slots) total += p?.size ?: 0
+            val out = ByteArray(total)
+            var o = 0
+            for (p in slots) {
+                if (p == null) continue
+                System.arraycopy(p, 0, out, o, p.size)
+                o += p.size
+            }
+            return out
+        }
+    }
+}

--- a/clients/android/app/src/main/java/com/orbiscreen/android/ui/nav/OrbiNav.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/ui/nav/OrbiNav.kt
@@ -38,13 +38,18 @@ object Routes {
 }
 
 @Composable
-fun OrbiNav(prefs: PrefsStore) {
+fun OrbiNav(prefs: PrefsStore, startHost: String? = null, startPort: Int = 8788) {
     val nav = rememberNavController()
     val appContext = LocalContext.current.applicationContext
+    val start = if (!startHost.isNullOrBlank()) {
+        Routes.stream(startHost, startPort)
+    } else {
+        Routes.DISCOVERY
+    }
 
     NavHost(
         navController = nav,
-        startDestination = Routes.DISCOVERY,
+        startDestination = start,
         enterTransition = { slideInHorizontally(animationSpec = tween(220)) { it / 4 } + fadeIn(tween(220)) },
         exitTransition = { fadeOut(tween(120)) },
         popEnterTransition = { slideInHorizontally(animationSpec = tween(220)) { it / 4 } + fadeIn(tween(220)) },

--- a/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/ContentRect.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/ContentRect.kt
@@ -1,0 +1,24 @@
+// Orbiscreen - ContentRect.kt (GPL-3.0-or-later)
+// https://github.com/shadow-x78/orbiscreen
+
+package com.orbiscreen.android.ui.stream
+
+internal data class ContentRect(val offsetX: Float, val offsetY: Float, val w: Float, val h: Float)
+
+internal fun computeContentRect(viewW: Int, viewH: Int, streamW: Int, streamH: Int, scaleMode: Int = 0): ContentRect {
+    if (streamW <= 0 || streamH <= 0 || viewW <= 0 || viewH <= 0) {
+        return ContentRect(0f, 0f, viewW.toFloat().coerceAtLeast(1f), viewH.toFloat().coerceAtLeast(1f))
+    }
+    if (scaleMode == 3) {
+        return ContentRect(0f, 0f, viewW.toFloat(), viewH.toFloat())
+    }
+    val streamAspect = streamW.toFloat() / streamH.toFloat()
+    val viewAspect = viewW.toFloat() / viewH.toFloat()
+    return if (streamAspect > viewAspect) {
+        val contentH = viewW / streamAspect
+        ContentRect(0f, (viewH - contentH) / 2f, viewW.toFloat(), contentH)
+    } else {
+        val contentW = viewH * streamAspect
+        ContentRect((viewW - contentW) / 2f, 0f, contentW, viewH.toFloat())
+    }
+}

--- a/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/ControlToolbar.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/ControlToolbar.kt
@@ -52,6 +52,7 @@ fun ControlToolbar(
     hostLabel: String,
     encoder: String,
     resolution: String,
+    delayMs: Int? = null,
     isTouchMode: Boolean = false,
     onToggleInputMode: () -> Unit = {},
     onToggleKeyboard: () -> Unit,
@@ -85,28 +86,36 @@ fun ControlToolbar(
                         .clip(CircleShape)
                         .background(ActiveGreen),
                 )
+            }
 
-                Column(modifier = Modifier.padding(end = 6.dp)) {
+            Column(modifier = Modifier.padding(end = 6.dp)) {
+                if (!isPortrait) {
                     Text(
                         text = hostLabel,
                         style = MaterialTheme.typography.labelLarge,
                         color = Color.White,
                         fontWeight = FontWeight.Bold,
                     )
-                    val info = listOfNotNull(
-                        resolution.takeIf { it.isNotBlank() },
-                        encoder.takeIf { it.isNotBlank() },
-                    ).joinToString("  ")
-                    if (info.isNotBlank()) {
-                        Text(
-                            text = info,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = Color.White.copy(alpha = 0.7f),
-                            fontSize = 10.sp,
-                        )
-                    }
                 }
+                val delayText = if (delayMs != null && delayMs >= 0) {
+                    "delay ${delayMs}ms"
+                } else {
+                    "delay —"
+                }
+                val info = listOfNotNull(
+                    resolution.takeIf { it.isNotBlank() && !isPortrait },
+                    encoder.takeIf { it.isNotBlank() && !isPortrait },
+                    delayText,
+                ).joinToString("  ")
+                Text(
+                    text = info,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Color.White.copy(alpha = 0.7f),
+                    fontSize = 10.sp,
+                )
+            }
 
+            if (!isPortrait) {
                 Spacer(Modifier.width(2.dp))
             }
 

--- a/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/PlayerSurface.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/PlayerSurface.kt
@@ -3,40 +3,28 @@
 
 package com.orbiscreen.android.ui.stream
 
+import android.content.Context
+import android.graphics.Color
 import android.util.Log
 import android.view.MotionEvent
+import android.view.SurfaceHolder
+import android.view.SurfaceView
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import androidx.annotation.OptIn
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
+import com.orbiscreen.android.player.UdpPlayer
+import kotlin.math.roundToInt
 
 private const val TAG = "Orbi.Surface"
-
-internal data class ContentRect(val offsetX: Float, val offsetY: Float, val w: Float, val h: Float)
-
-internal fun computeContentRect(viewW: Int, viewH: Int, streamW: Int, streamH: Int, scaleMode: Int = 0): ContentRect {
-    if (streamW <= 0 || streamH <= 0 || viewW <= 0 || viewH <= 0) {
-        return ContentRect(0f, 0f, viewW.toFloat().coerceAtLeast(1f), viewH.toFloat().coerceAtLeast(1f))
-    }
-    if (scaleMode == 3) {
-        return ContentRect(0f, 0f, viewW.toFloat(), viewH.toFloat())
-    }
-    val streamAspect = streamW.toFloat() / streamH.toFloat()
-    val viewAspect = viewW.toFloat() / viewH.toFloat()
-    return if (streamAspect > viewAspect) {
-        val contentH = viewW / streamAspect
-        ContentRect(0f, (viewH - contentH) / 2f, viewW.toFloat(), contentH)
-    } else {
-        val contentW = viewH * streamAspect
-        ContentRect((viewW - contentW) / 2f, 0f, contentW, viewH.toFloat())
-    }
-}
 
 private class TouchCallbacksHolder(
     var isTouchMode: Boolean,
@@ -50,12 +38,70 @@ private class TouchCallbacksHolder(
     var onDoubleTap: (() -> Unit)?,
     var onStylus: ((Float, Float, Int, Int, Float, Float, Float) -> Unit)? = null,
     var scaleMode: Int = 0,
+    var streamWidth: Int = 1920,
+    var streamHeight: Int = 1080,
 )
+
+private class UdpVideoLayout(ctx: Context) : FrameLayout(ctx) {
+    private val surfaceView = SurfaceView(ctx)
+    private var bound: UdpPlayer? = null
+    private var streamW = 1920
+    private var streamH = 1080
+    private var scaleMode = 0
+    private val callback = object : SurfaceHolder.Callback {
+        override fun surfaceCreated(sh: SurfaceHolder) {
+            bound?.attachSurface(sh.surface)
+        }
+        override fun surfaceChanged(sh: SurfaceHolder, format: Int, w: Int, hgt: Int) {
+            bound?.attachSurface(sh.surface)
+        }
+        override fun surfaceDestroyed(sh: SurfaceHolder) {
+            bound?.detachSurface()
+        }
+    }
+
+    init {
+        setBackgroundColor(Color.BLACK)
+        keepScreenOn = true
+        surfaceView.holder.addCallback(callback)
+        addView(surfaceView)
+    }
+
+    fun bindPlayer(udp: UdpPlayer?) {
+        if (bound === udp) {
+            if (udp != null && surfaceView.holder.surface.isValid) {
+                udp.attachSurface(surfaceView.holder.surface)
+            }
+            return
+        }
+        bound?.detachSurface()
+        bound = udp
+        if (udp != null && surfaceView.holder.surface.isValid) {
+            udp.attachSurface(surfaceView.holder.surface)
+        }
+    }
+
+    fun setStream(width: Int, height: Int, mode: Int) {
+        if (streamW == width && streamH == height && scaleMode == mode) return
+        streamW = width
+        streamH = height
+        scaleMode = mode
+        requestLayout()
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        val cr = computeContentRect(right - left, bottom - top, streamW, streamH, scaleMode)
+        val sl = cr.offsetX.roundToInt()
+        val st = cr.offsetY.roundToInt()
+        surfaceView.layout(sl, st, sl + cr.w.roundToInt().coerceAtLeast(1), st + cr.h.roundToInt().coerceAtLeast(1))
+    }
+}
 
 @OptIn(UnstableApi::class)
 @Composable
 fun PlayerSurface(
     player: ExoPlayer?,
+    udp: UdpPlayer? = null,
     isTouchMode: Boolean,
     onMove: (Float, Float, Int, Int) -> Unit,
     onPointer: (Float?, Float?, Int, Int, Int, Boolean) -> Unit,
@@ -88,6 +134,8 @@ fun PlayerSurface(
 
     holder.isTouchMode = isTouchMode
     holder.scaleMode = scaleMode
+    holder.streamWidth = streamWidth
+    holder.streamHeight = streamHeight
     holder.onMove = onMove
     holder.onPointer = onPointer
     holder.onTouch = onTouch
@@ -98,6 +146,7 @@ fun PlayerSurface(
     holder.onDoubleTap = onDoubleTap
     holder.onStylus = onStylus
 
+    key(udp != null, udp) {
     AndroidView(
         modifier = modifier.fillMaxSize(),
         factory = { ctx ->
@@ -114,6 +163,16 @@ fun PlayerSurface(
             val doubleTapMaxMs = 300L
             val doubleTapMaxDistPx = 80f
 
+            val video = if (udp != null) {
+                UdpVideoLayout(ctx).apply {
+                    layoutParams = ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                    )
+                    bindPlayer(udp)
+                    setStream(holder.streamWidth, holder.streamHeight, holder.scaleMode)
+                }
+            } else {
             PlayerView(ctx).apply {
                 useController = false
                 layoutParams = ViewGroup.LayoutParams(
@@ -123,6 +182,11 @@ fun PlayerSurface(
                 setShutterBackgroundColor(android.graphics.Color.TRANSPARENT)
                 keepScreenOn = true
                 resizeMode = scaleMode
+                this.player = player
+            }
+            }
+            video.apply {
+                keepScreenOn = true
                 isClickable = true
                 isFocusable = true
                 requestFocus()
@@ -130,7 +194,7 @@ fun PlayerSurface(
                 setOnGenericMotionListener { _, ev ->
                     val toolType = ev.getToolType(0)
                     if ((toolType == MotionEvent.TOOL_TYPE_STYLUS || toolType == MotionEvent.TOOL_TYPE_ERASER) && holder.onStylus != null) {
-                        val cr = computeContentRect(width, height, streamWidth, streamHeight, holder.scaleMode)
+                        val cr = computeContentRect(width, height, holder.streamWidth, holder.streamHeight, holder.scaleMode)
                         val cx = (ev.x - cr.offsetX).coerceIn(0f, cr.w)
                         val cy = (ev.y - cr.offsetY).coerceIn(0f, cr.h)
                         val pressure = ev.pressure
@@ -151,7 +215,7 @@ fun PlayerSurface(
                     val toolType = ev.getToolType(0)
                     val isStylus = toolType == MotionEvent.TOOL_TYPE_STYLUS || toolType == MotionEvent.TOOL_TYPE_ERASER
                     if (isStylus && holder.onStylus != null) {
-                        val cr = computeContentRect(w, hPx, streamWidth, streamHeight, holder.scaleMode)
+                        val cr = computeContentRect(w, hPx, holder.streamWidth, holder.streamHeight, holder.scaleMode)
                         val cx = (ev.x - cr.offsetX).coerceIn(0f, cr.w)
                         val cy = (ev.y - cr.offsetY).coerceIn(0f, cr.h)
                         val pressure = if (ev.actionMasked == MotionEvent.ACTION_UP || ev.actionMasked == MotionEvent.ACTION_CANCEL) 0f else ev.pressure.coerceAtLeast(0.1f)
@@ -165,7 +229,7 @@ fun PlayerSurface(
                     }
 
                     if (holder.isTouchMode) {
-                        val cr = computeContentRect(w, hPx, streamWidth, streamHeight, holder.scaleMode)
+                        val cr = computeContentRect(w, hPx, holder.streamWidth, holder.streamHeight, holder.scaleMode)
                         val cw = cr.w.toInt().coerceAtLeast(1)
                         val ch = cr.h.toInt().coerceAtLeast(1)
                         val mapped = { idx: Int ->
@@ -233,9 +297,9 @@ fun PlayerSurface(
                                     val dy = ev.y - lastY
                                     if (kotlin.math.abs(dx) > 1.5f || kotlin.math.abs(dy) > 1.5f) {
                                         moved = true
-                                        val cr = computeContentRect(w, hPx, streamWidth, streamHeight, holder.scaleMode)
-                                        val scaleX = streamWidth.toFloat() / cr.w.coerceAtLeast(1f)
-                                        val scaleY = streamHeight.toFloat() / cr.h.coerceAtLeast(1f)
+                                        val cr = computeContentRect(w, hPx, holder.streamWidth, holder.streamHeight, holder.scaleMode)
+                                        val scaleX = holder.streamWidth.toFloat() / cr.w.coerceAtLeast(1f)
+                                        val scaleY = holder.streamHeight.toFloat() / cr.h.coerceAtLeast(1f)
                                         holder.onDeltaMove(dx * scaleX, dy * scaleY)
                                         lastX = ev.x
                                         lastY = ev.y
@@ -285,8 +349,15 @@ fun PlayerSurface(
             }
         },
         update = { view ->
-            view.player = player
-            view.resizeMode = scaleMode
+            (view as? PlayerView)?.let {
+                it.player = player
+                it.resizeMode = scaleMode
+            }
+            (view as? UdpVideoLayout)?.let {
+                it.bindPlayer(udp)
+                it.setStream(holder.streamWidth, holder.streamHeight, holder.scaleMode)
+            }
         },
     )
+    }
 }

--- a/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/StreamScreen.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/StreamScreen.kt
@@ -133,6 +133,7 @@ fun StreamScreen(
 ) {
     val state by viewModel.state.collectAsState()
     val player = viewModel.player.collectAsState().value
+    val udp = viewModel.udpPlayer.collectAsState().value
     var showControls by remember { mutableStateOf(false) }
     var showSettingsSheet by remember { mutableStateOf(false) }
     var showExitConfirmDialog by remember { mutableStateOf(false) }
@@ -179,7 +180,7 @@ fun StreamScreen(
 
     LaunchedEffect(showControls) {
         if (showControls) {
-            delay(4000)
+            delay(12_000)
             showControls = false
         }
     }
@@ -232,10 +233,12 @@ fun StreamScreen(
             label = "cornerFab",
         )
 
-        if (player != null) {
+        val udpLat = udp?.latencyMs?.collectAsState()?.value
+        if (player != null || udp != null) {
             val input = remember { viewModel.ensureInput() }
             PlayerSurface(
                 player = player,
+                udp = udp,
                 isTouchMode = isTouchMode,
                 streamWidth = state.displayWidth,
                 streamHeight = state.displayHeight,
@@ -262,7 +265,6 @@ fun StreamScreen(
                 } else null,
             )
         }
-
         if (state.event !is StreamEvent.Playing && state.event !is StreamEvent.Buffering) {
             StatusOverlay(
                 event = state.event,
@@ -279,8 +281,9 @@ fun StreamScreen(
         ) {
             ControlToolbar(
                 hostLabel = if (state.host == "127.0.0.1") "USB · Orbiscreen" else state.host,
-                encoder = state.encoder,
+                encoder = if (udp != null) "${state.encoder} · UDP" else state.encoder,
                 resolution = "${state.displayWidth}×${state.displayHeight}",
+                delayMs = udpLat,
                 isTouchMode = isTouchMode,
                 onToggleInputMode = {
                     isTouchMode = !isTouchMode

--- a/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/StreamViewModel.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/ui/stream/StreamViewModel.kt
@@ -58,6 +58,7 @@ class StreamViewModel(
     val state: StateFlow<StreamState> = _state.asStateFlow()
 
     val player get() = playerHolder.player
+    val udpPlayer get() = playerHolder.udpPlayer
 
     private suspend fun freshToken(forceRefresh: Boolean = false): String {
         return withContext(Dispatchers.IO) {

--- a/clients/android/app/src/test/java/com/orbiscreen/android/player/UdpPmtuTest.kt
+++ b/clients/android/app/src/test/java/com/orbiscreen/android/player/UdpPmtuTest.kt
@@ -1,0 +1,43 @@
+// Orbiscreen - UdpPmtuTest.kt (GPL-3.0-or-later)
+// https://github.com/shadow-x78/orbiscreen
+package com.orbiscreen.android.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UdpPmtuTest {
+
+    @Test
+    fun probeAckEncodesReceivedDatagramSize() {
+        val ack = UdpPlayer.encodeProbeAck(9, 900)
+        assertEquals(9, ack.size)
+        assertEquals('O'.code.toByte(), ack[0])
+        assertEquals('R'.code.toByte(), ack[1])
+        assertEquals('B'.code.toByte(), ack[2])
+        assertEquals('1'.code.toByte(), ack[3])
+        assertEquals(8.toByte(), ack[4])
+        assertEquals(9, UdpPlayer.le16(ack, 5))
+        assertEquals(900, UdpPlayer.le16(ack, 7))
+    }
+
+    @Test
+    fun handshakeAcceptsAckAndKeepsWaitingOnProbe() {
+        val ack = byteArrayOf(
+            'O'.code.toByte(), 'R'.code.toByte(), 'B'.code.toByte(), '1'.code.toByte(), 3,
+        )
+        val probe = UdpPlayer.encodeCtrl(7)
+        val junk = byteArrayOf(1, 2, 3)
+        assertEquals(HandshakeAction.Ack, UdpPlayer.handshakeAction(ack))
+        assertEquals(HandshakeAction.Control, UdpPlayer.handshakeAction(probe))
+        assertEquals(HandshakeAction.Ignore, UdpPlayer.handshakeAction(junk))
+    }
+
+    @Test
+    fun putLe16Roundtrip() {
+        val buf = ByteArray(4)
+        UdpPlayer.putLe16(buf, 0, 0x1234)
+        UdpPlayer.putLe16(buf, 2, 1472)
+        assertEquals(0x1234, UdpPlayer.le16(buf, 0))
+        assertEquals(1472, UdpPlayer.le16(buf, 2))
+    }
+}

--- a/clients/android/app/src/test/java/com/orbiscreen/android/ui/stream/ContentRectTest.kt
+++ b/clients/android/app/src/test/java/com/orbiscreen/android/ui/stream/ContentRectTest.kt
@@ -1,0 +1,27 @@
+// Orbiscreen - ContentRectTest.kt (GPL-3.0-or-later)
+// https://github.com/shadow-x78/orbiscreen
+package com.orbiscreen.android.ui.stream
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ContentRectTest {
+
+    @Test
+    fun letterboxWideStreamInTallView() {
+        val cr = computeContentRect(1080, 1920, 2560, 1600, 0)
+        assertEquals(0f, cr.offsetX)
+        assertEquals(1080f, cr.w)
+        assertEquals((1920f - cr.h) / 2f, cr.offsetY, 0.5f)
+        assertEquals(1080f / (2560f / 1600f), cr.h, 0.5f)
+    }
+
+    @Test
+    fun fillIgnoresAspect() {
+        val cr = computeContentRect(1080, 1920, 2560, 1600, 3)
+        assertEquals(0f, cr.offsetX)
+        assertEquals(0f, cr.offsetY)
+        assertEquals(1080f, cr.w)
+        assertEquals(1920f, cr.h)
+    }
+}

--- a/crates/orbiscreen-capture/src/kwin_virtual.rs
+++ b/crates/orbiscreen-capture/src/kwin_virtual.rs
@@ -225,6 +225,207 @@ fn atomic_write(path: &Path, contents: &str) -> std::io::Result<()> {
     std::fs::rename(&tmp, path)
 }
 
+pub const VIRTUAL_OUTPUT_CONNECTOR: &str = "Virtual-ORBISCREEN";
+
+pub fn kwin_output_config_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(PathBuf::from(home).join(".config/kwinoutputconfig.json"))
+}
+
+pub fn forget_saved_virtual_output(path: &Path, connector: &str) -> std::io::Result<bool> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e),
+    };
+    let mut root: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(_) => return Ok(false),
+    };
+    fn strip(value: &mut serde_json::Value, connector: &str) -> bool {
+        let mut changed = false;
+        match value {
+            serde_json::Value::Array(items) => {
+                let before = items.len();
+                items.retain(
+                    |entry| match entry.get("connectorName").and_then(|v| v.as_str()) {
+                        Some(name) => {
+                            name != connector && !name.starts_with(&format!("{connector}-"))
+                        }
+                        None => true,
+                    },
+                );
+                if items.len() != before {
+                    changed = true;
+                }
+                for item in items.iter_mut() {
+                    if strip(item, connector) {
+                        changed = true;
+                    }
+                }
+            }
+            serde_json::Value::Object(map) => {
+                for child in map.values_mut() {
+                    if strip(child, connector) {
+                        changed = true;
+                    }
+                }
+            }
+            _ => {}
+        }
+        changed
+    }
+    if !strip(&mut root, connector) {
+        return Ok(false);
+    }
+    let pretty = serde_json::to_string_pretty(&root)
+        .map_err(|e| std::io::Error::other(format!("serialize kwin output config: {e}")))?;
+    atomic_write(path, &pretty)?;
+    Ok(true)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KscreenOutput {
+    pub name: String,
+    pub uuid: Option<String>,
+    pub enabled: bool,
+}
+
+fn strip_ansi(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' && chars.peek() == Some(&'[') {
+            chars.next();
+            for next in chars.by_ref() {
+                if next.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+pub fn parse_kscreen_outputs(text: &str) -> Vec<KscreenOutput> {
+    let text = strip_ansi(text);
+    let mut current: Option<KscreenOutput> = None;
+    let mut out = Vec::new();
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix("Output: ") {
+            if let Some(done) = current.take() {
+                out.push(done);
+            }
+            let mut parts = rest.split_whitespace();
+            let _idx = parts.next();
+            if let Some(name) = parts.next() {
+                let uuid = parts
+                    .next()
+                    .filter(|tok| tok.contains('-'))
+                    .map(str::to_string);
+                current = Some(KscreenOutput {
+                    name: name.to_string(),
+                    uuid,
+                    enabled: false,
+                });
+            }
+        } else if line.trim() == "enabled" {
+            if let Some(cur) = current.as_mut() {
+                cur.enabled = true;
+            }
+        } else if line.trim() == "disabled" {
+            if let Some(cur) = current.as_mut() {
+                cur.enabled = false;
+            }
+        }
+    }
+    if let Some(done) = current {
+        out.push(done);
+    }
+    out
+}
+
+fn is_portal_virtual_output(name: &str) -> bool {
+    name.starts_with("Virtual-virtual-xdp-kde")
+}
+
+pub fn list_kscreen_outputs() -> Vec<KscreenOutput> {
+    let out = std::process::Command::new("kscreen-doctor")
+        .arg("-o")
+        .env("TERM", "dumb")
+        .env("NO_COLOR", "1")
+        .output();
+    match out {
+        Ok(out) if out.status.success() => {
+            parse_kscreen_outputs(&String::from_utf8_lossy(&out.stdout))
+        }
+        _ => Vec::new(),
+    }
+}
+
+pub fn select_tablet_output(outputs: &[KscreenOutput], preferred: Option<&str>) -> Option<String> {
+    let enabled: Vec<&str> = outputs
+        .iter()
+        .filter(|o| o.enabled)
+        .map(|o| o.name.as_str())
+        .collect();
+    if let Some(name) = preferred {
+        if enabled.contains(&name) {
+            return Some(name.to_string());
+        }
+    }
+    if let Some(name) = enabled
+        .iter()
+        .copied()
+        .find(|n| n.starts_with("Virtual-ORBISCREEN-"))
+    {
+        return Some(name.to_string());
+    }
+    if enabled.contains(&VIRTUAL_OUTPUT_CONNECTOR) {
+        return Some(VIRTUAL_OUTPUT_CONNECTOR.to_string());
+    }
+    None
+}
+
+pub fn output_uuid(name: &str) -> Option<String> {
+    list_kscreen_outputs()
+        .into_iter()
+        .find(|o| o.enabled && o.name == name)
+        .and_then(|o| o.uuid)
+}
+
+pub fn preferred_tablet_output(preferred: Option<&str>) -> Option<String> {
+    select_tablet_output(&list_kscreen_outputs(), preferred)
+}
+
+pub fn disable_stale_portal_virtual_outputs() {
+    for output in list_kscreen_outputs() {
+        if output.enabled && is_portal_virtual_output(&output.name) {
+            let spec = format!("output.{}.disable", output.name);
+            match std::process::Command::new("kscreen-doctor")
+                .arg(&spec)
+                .status()
+            {
+                Ok(status) if status.success() => tracing::info!(
+                    output = %output.name,
+                    "disabled portal virtual output"
+                ),
+                Ok(status) => tracing::warn!(
+                    output = %output.name,
+                    %status,
+                    "kscreen-doctor failed to disable portal virtual output"
+                ),
+                Err(e) => tracing::warn!(
+                    output = %output.name,
+                    "could not run kscreen-doctor to disable portal virtual output: {e}"
+                ),
+            }
+        }
+    }
+}
+
 fn client_executable() -> std::io::Result<PathBuf> {
     if let Some(appimage) = std::env::var_os("APPIMAGE")
         .map(PathBuf::from)
@@ -305,6 +506,7 @@ pub struct KwinVirtualCapture {
     rx: tokio::sync::Mutex<mpsc::Receiver<CapturedFrame>>,
     width: u32,
     height: u32,
+    connector: String,
     stop: Arc<AtomicBool>,
     ended: Arc<AtomicBool>,
     ended_notify: Arc<Notify>,
@@ -315,6 +517,24 @@ pub struct KwinVirtualCapture {
 impl KwinVirtualCapture {
     #[instrument(skip_all, fields(width = spec.width, height = spec.height))]
     pub fn open(spec: KwinVirtualSpec) -> Result<Self, KwinVirtualError> {
+        if let Some(path) = kwin_output_config_path() {
+            let pid_connector = format!("Virtual-ORBISCREEN-{}", std::process::id());
+            for connector in [VIRTUAL_OUTPUT_CONNECTOR, pid_connector.as_str()] {
+                match forget_saved_virtual_output(&path, connector) {
+                    Ok(true) => tracing::info!(
+                        file = %path.display(),
+                        connector,
+                        "cleared stale KWin config"
+                    ),
+                    Ok(false) => {}
+                    Err(e) => tracing::warn!(
+                        file = %path.display(),
+                        connector,
+                        "could not clear stale KWin virtual output config: {e}"
+                    ),
+                }
+            }
+        }
         let Ok(width) = i32::try_from(spec.width) else {
             return Err(KwinVirtualError::UnsupportedSize(spec.width, spec.height));
         };
@@ -356,56 +576,90 @@ impl KwinVirtualCapture {
         let screencast: ZkdeScreencastUnstableV1 =
             registry.bind(global_name, version, &session.queue.handle(), ());
 
-        let shared = Arc::new(StreamShared::default());
-        let stream = if version >= 4 {
-            screencast.stream_virtual_output_with_description(
-                "ORBISCREEN".to_string(),
-                "Orbiscreen Virtual Display".to_string(),
-                width,
-                height,
-                1.0,
-                POINTER_EMBEDDED,
-                &session.queue.handle(),
-                shared.clone(),
-            )
-        } else {
-            screencast.stream_virtual_output(
-                "ORBISCREEN".to_string(),
-                width,
-                height,
-                1.0,
-                POINTER_EMBEDDED,
-                &session.queue.handle(),
-                shared.clone(),
-            )
-        };
+        let names = [
+            "ORBISCREEN".to_string(),
+            format!("ORBISCREEN-{}", std::process::id()),
+        ];
+        let mut last_err: Option<KwinVirtualError> = None;
+        let mut stream = None;
+        let mut node_id = None;
+        let mut shared_ok: Option<Arc<StreamShared>> = None;
+        let mut accepted_name: Option<String> = None;
+        for name in names {
+            let shared = Arc::new(StreamShared::default());
+            let candidate = if version >= 4 {
+                screencast.stream_virtual_output_with_description(
+                    name.clone(),
+                    "Orbiscreen Virtual Display".to_string(),
+                    width,
+                    height,
+                    1.0,
+                    POINTER_EMBEDDED,
+                    &session.queue.handle(),
+                    shared.clone(),
+                )
+            } else {
+                screencast.stream_virtual_output(
+                    name.clone(),
+                    width,
+                    height,
+                    1.0,
+                    POINTER_EMBEDDED,
+                    &session.queue.handle(),
+                    shared.clone(),
+                )
+            };
 
-        let deadline = Instant::now() + HANDSHAKE_DEADLINE;
-        let node_id = loop {
-            session
-                .queue
-                .roundtrip(&mut session.state)
-                .map_err(|e| KwinVirtualError::Wayland(e.to_string()))?;
-            if let Some(err) = shared
-                .failed
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .clone()
-            {
-                return Err(KwinVirtualError::StreamFailed(err));
+            let deadline = Instant::now() + HANDSHAKE_DEADLINE;
+            let result = loop {
+                session
+                    .queue
+                    .roundtrip(&mut session.state)
+                    .map_err(|e| KwinVirtualError::Wayland(e.to_string()))?;
+                if let Some(err) = shared
+                    .failed
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .clone()
+                {
+                    break Err(KwinVirtualError::StreamFailed(err));
+                }
+                if shared.closed.load(Ordering::Relaxed) {
+                    break Err(KwinVirtualError::StreamFailed(
+                        "compositor closed the stream during setup".into(),
+                    ));
+                }
+                if let Some(node) = *shared.node_id.lock().unwrap_or_else(|e| e.into_inner()) {
+                    break Ok(node);
+                }
+                if Instant::now() >= deadline {
+                    break Err(KwinVirtualError::Timeout);
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            };
+            match result {
+                Ok(id) => {
+                    tracing::info!(name, "KWin virtual display created via zkde-screencast");
+                    stream = Some(candidate);
+                    node_id = Some(id);
+                    shared_ok = Some(shared);
+                    accepted_name = Some(format!("Virtual-{name}"));
+                    break;
+                }
+                Err(e) => {
+                    tracing::warn!(name, "KWin virtual output '{name}' failed: {e}");
+                    drop(candidate);
+                    last_err = Some(e);
+                }
             }
-            if shared.closed.load(Ordering::Relaxed) {
-                return Err(KwinVirtualError::StreamFailed(
-                    "compositor closed the stream during setup".into(),
-                ));
+        }
+        let (stream, node_id, shared) = match (stream, node_id, shared_ok) {
+            (Some(stream), Some(node_id), Some(shared)) => (stream, node_id, shared),
+            _ => {
+                return Err(last_err.unwrap_or_else(|| {
+                    KwinVirtualError::StreamFailed("no virtual output".into())
+                }));
             }
-            if let Some(node) = *shared.node_id.lock().unwrap_or_else(|e| e.into_inner()) {
-                break node;
-            }
-            if Instant::now() >= deadline {
-                return Err(KwinVirtualError::Timeout);
-            }
-            std::thread::sleep(Duration::from_millis(10));
         };
 
         let pipeline_str = format!(
@@ -508,12 +762,17 @@ impl KwinVirtualCapture {
             rx: tokio::sync::Mutex::new(rx),
             width: spec.width,
             height: spec.height,
+            connector: accepted_name.unwrap_or_else(|| VIRTUAL_OUTPUT_CONNECTOR.to_string()),
             stop,
             ended,
             ended_notify,
             event_thread: Some(event_thread),
             _damage_pump: damage_pump,
         })
+    }
+
+    pub fn connector_name(&self) -> &str {
+        &self.connector
     }
 
     pub fn dimensions(&self) -> (u32, u32) {
@@ -605,4 +864,103 @@ fn pump_events(
     }
     ended.store(true, Ordering::Relaxed);
     ended_notify.notify_one();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forget_saved_virtual_output_drops_connector() {
+        let dir = std::env::temp_dir().join(format!("orbi-kwin-cfg-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("kwinoutputconfig.json");
+        std::fs::write(
+            &path,
+            r#"[{
+                "data": [
+                    {"connectorName": "eDP-1"},
+                    {"connectorName": "Virtual-ORBISCREEN", "uuid": "dead"}
+                ]
+            }]"#,
+        )
+        .unwrap();
+        assert!(forget_saved_virtual_output(&path, VIRTUAL_OUTPUT_CONNECTOR).unwrap());
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(!raw.contains("Virtual-ORBISCREEN"));
+        assert!(raw.contains("eDP-1"));
+        assert!(!forget_saved_virtual_output(&path, VIRTUAL_OUTPUT_CONNECTOR).unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn parse_kscreen_doctor_outputs() {
+        let text = "\
+\u{1b}[01;32mOutput: \u{1b}[0;0m1 eDP-1 8d4cd7b2-4072-46fe-9076-a472ff599d3e
+\u{1b}[01;32menabled\u{1b}[0;0m
+connected
+Geometry: 0,0 1920x1200
+Output: 2 DP-6 2185e147-5700-4a76-95c7-4ca01c705bea
+enabled
+Geometry: 1920,0 2560x1440
+Output: 3 Virtual-virtual-xdp-kde- 3ab51ad6-f454-4c80-bee1-bb69124801de
+enabled
+Geometry: 4480,0 1920x1080
+Output: 4 Virtual-ORBISCREEN deadbeef-0000-0000-0000-000000000000
+disabled
+";
+        let outs = parse_kscreen_outputs(text);
+        assert_eq!(
+            outs,
+            vec![
+                KscreenOutput {
+                    name: "eDP-1".into(),
+                    uuid: Some("8d4cd7b2-4072-46fe-9076-a472ff599d3e".into()),
+                    enabled: true
+                },
+                KscreenOutput {
+                    name: "DP-6".into(),
+                    uuid: Some("2185e147-5700-4a76-95c7-4ca01c705bea".into()),
+                    enabled: true
+                },
+                KscreenOutput {
+                    name: "Virtual-virtual-xdp-kde-".into(),
+                    uuid: Some("3ab51ad6-f454-4c80-bee1-bb69124801de".into()),
+                    enabled: true
+                },
+                KscreenOutput {
+                    name: "Virtual-ORBISCREEN".into(),
+                    uuid: Some("deadbeef-0000-0000-0000-000000000000".into()),
+                    enabled: false
+                },
+            ]
+        );
+        assert_eq!(
+            select_tablet_output(&outs, Some(VIRTUAL_OUTPUT_CONNECTOR)).as_deref(),
+            None
+        );
+        let mut with_orbi = outs.clone();
+        with_orbi[3].enabled = true;
+        assert_eq!(
+            select_tablet_output(&with_orbi, Some(VIRTUAL_OUTPUT_CONNECTOR)).as_deref(),
+            Some(VIRTUAL_OUTPUT_CONNECTOR)
+        );
+        with_orbi.push(KscreenOutput {
+            name: "Virtual-ORBISCREEN-123".into(),
+            uuid: Some("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".into()),
+            enabled: true,
+        });
+        assert_eq!(
+            select_tablet_output(&with_orbi, Some("Virtual-ORBISCREEN-123")).as_deref(),
+            Some("Virtual-ORBISCREEN-123")
+        );
+        assert_eq!(
+            select_tablet_output(&with_orbi, Some(VIRTUAL_OUTPUT_CONNECTOR)).as_deref(),
+            Some(VIRTUAL_OUTPUT_CONNECTOR)
+        );
+        assert_eq!(
+            select_tablet_output(&with_orbi, None).as_deref(),
+            Some("Virtual-ORBISCREEN-123")
+        );
+    }
 }

--- a/crates/orbiscreen-capture/src/lib.rs
+++ b/crates/orbiscreen-capture/src/lib.rs
@@ -43,6 +43,8 @@ pub enum CaptureError {
     X11Protocol(u8),
     #[error("capture I/O error: {0}")]
     Io(String),
+    #[error("virtual output parked")]
+    Parked,
 }
 
 impl From<x11rb::xcb_ffi::ConnectError> for CaptureError {
@@ -144,11 +146,75 @@ pub(crate) fn sample_to_captured_frame(
     })
 }
 
+struct KwinSlot {
+    capture: Option<std::sync::Arc<kwin_virtual::KwinVirtualCapture>>,
+    width: u32,
+    height: u32,
+    connector: Option<String>,
+}
+
+#[derive(Clone)]
+#[allow(missing_debug_implementations)]
+pub struct VirtualOutputLease {
+    kwin: Option<std::sync::Arc<tokio::sync::Mutex<KwinSlot>>>,
+}
+
+impl VirtualOutputLease {
+    pub fn none() -> Self {
+        Self { kwin: None }
+    }
+
+    pub async fn park(&self) {
+        let Some(slot) = &self.kwin else {
+            return;
+        };
+        let mut guard = slot.lock().await;
+        if guard.capture.take().is_some() {
+            tracing::info!("parked KWin virtual output");
+        }
+    }
+
+    pub async fn unpark(&self) -> Result<bool, CaptureError> {
+        let Some(slot) = &self.kwin else {
+            return Ok(false);
+        };
+        let (width, height) = {
+            let guard = slot.lock().await;
+            if guard.capture.is_some() {
+                return Ok(false);
+            }
+            (guard.width, guard.height)
+        };
+        let capture = tokio::task::spawn_blocking(move || {
+            kwin_virtual::KwinVirtualCapture::open(kwin_virtual::KwinVirtualSpec { width, height })
+        })
+        .await
+        .map_err(|e| CaptureError::Io(format!("kwin-virtual unpark task: {e}")))??;
+        let connector = capture.connector_name().to_string();
+        {
+            let mut guard = slot.lock().await;
+            guard.connector = Some(connector.clone());
+            guard.capture = Some(std::sync::Arc::new(capture));
+        }
+        tracing::info!(connector, "restored KWin virtual output");
+        Ok(true)
+    }
+
+    pub fn is_kwin(&self) -> bool {
+        self.kwin.is_some()
+    }
+
+    pub async fn connector_name(&self) -> Option<String> {
+        let slot = self.kwin.as_ref()?;
+        slot.lock().await.connector.clone()
+    }
+}
+
 #[allow(missing_debug_implementations)]
 enum CaptureInner {
     X11(x11::X11Capture),
     Wayland(wayland::WaylandCapture),
-    KwinVirtual(kwin_virtual::KwinVirtualCapture),
+    KwinVirtual(std::sync::Arc<tokio::sync::Mutex<KwinSlot>>),
     WlrScreencopy(wlr_screencopy::WlrScreencopyCapture),
 }
 
@@ -189,9 +255,16 @@ impl CaptureSession {
         tracing::info!(
             "KWin virtual display created via zkde-screencast: no root, no share dialog"
         );
+        let connector = capture.connector_name().to_string();
+        let slot = std::sync::Arc::new(tokio::sync::Mutex::new(KwinSlot {
+            capture: Some(std::sync::Arc::new(capture)),
+            width: actual_w,
+            height: actual_h,
+            connector: Some(connector),
+        }));
         Ok(Self {
             backend_kind: CaptureBackend::KwinVirtual,
-            inner: Arc::new(CaptureInner::KwinVirtual(capture)),
+            inner: Arc::new(CaptureInner::KwinVirtual(slot)),
             width: actual_w,
             height: actual_h,
         })
@@ -257,9 +330,29 @@ impl CaptureSession {
 
     pub fn is_ended(&self) -> bool {
         match self.inner.as_ref() {
-            CaptureInner::KwinVirtual(capture) => capture.is_ended(),
+            CaptureInner::KwinVirtual(slot) => slot
+                .try_lock()
+                .ok()
+                .and_then(|g| g.capture.as_ref().map(|c| c.is_ended()))
+                .unwrap_or(false),
             CaptureInner::WlrScreencopy(capture) => capture.is_ended(),
             CaptureInner::X11(_) | CaptureInner::Wayland(_) => false,
+        }
+    }
+
+    pub fn virtual_output_lease(&self) -> VirtualOutputLease {
+        match self.inner.as_ref() {
+            CaptureInner::KwinVirtual(slot) => VirtualOutputLease {
+                kwin: Some(slot.clone()),
+            },
+            _ => VirtualOutputLease { kwin: None },
+        }
+    }
+
+    pub async fn virtual_output_name(&self) -> Option<String> {
+        match self.inner.as_ref() {
+            CaptureInner::KwinVirtual(slot) => slot.lock().await.connector.clone(),
+            _ => None,
         }
     }
 
@@ -275,7 +368,13 @@ impl CaptureSession {
         match self.inner.as_ref() {
             CaptureInner::X11(capture) => capture.next_frame().await,
             CaptureInner::Wayland(capture) => capture.next_frame().await,
-            CaptureInner::KwinVirtual(capture) => capture.next_frame().await,
+            CaptureInner::KwinVirtual(slot) => {
+                let cap = slot.lock().await.capture.clone();
+                match cap {
+                    Some(capture) => capture.next_frame().await,
+                    None => Err(CaptureError::Parked),
+                }
+            }
             CaptureInner::WlrScreencopy(capture) => capture.next_frame().await,
         }
     }

--- a/crates/orbiscreen-daemon/src/main.rs
+++ b/crates/orbiscreen-daemon/src/main.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use clap::{Parser, Subcommand};
 use orbiscreen_capture::capabilities::{Capabilities, CaptureStep};
 use orbiscreen_capture::wlr_virtual_output::{VirtualOutputSpec, WlrootsVirtualOutput};
-use orbiscreen_capture::{CaptureBackend, CapturePreference, CaptureSession};
+use orbiscreen_capture::{CapturePreference, CaptureSession};
 use orbiscreen_core::{dump_config, load_config, Config};
 use orbiscreen_display::{DisplayStatus, EvdiFramePump, VirtualDisplaySpec};
 use orbiscreen_encode::{EncodeParams, Encoder, EncoderKind};
@@ -206,6 +206,7 @@ enum FrameSource {
 enum SourceOutcome {
     Frame(Frame),
     Retryable(String),
+    Parked,
     Ended,
 }
 
@@ -226,6 +227,7 @@ impl FrameSource {
                     height: frame.height,
                     data: frame.data,
                 }),
+                Err(orbiscreen_capture::CaptureError::Parked) => SourceOutcome::Parked,
                 Err(e) => SourceOutcome::Retryable(e.to_string()),
             },
             FrameSource::WlrVirtual { session, .. } => match session.next_frame().await {
@@ -234,6 +236,7 @@ impl FrameSource {
                     height: frame.height,
                     data: frame.data,
                 }),
+                Err(orbiscreen_capture::CaptureError::Parked) => SourceOutcome::Parked,
                 Err(e) => SourceOutcome::Retryable(e.to_string()),
             },
         }
@@ -265,6 +268,24 @@ impl FrameSource {
             FrameSource::Evdi(pump, _) => pump.actual_dimensions(),
             FrameSource::Capture(capture) => (capture.width(), capture.height()),
             FrameSource::WlrVirtual { session, .. } => (session.width(), session.height()),
+        }
+    }
+
+    fn virtual_output_lease(&self) -> orbiscreen_capture::VirtualOutputLease {
+        match self {
+            FrameSource::Capture(capture)
+            | FrameSource::WlrVirtual {
+                session: capture, ..
+            } => capture.virtual_output_lease(),
+            FrameSource::Evdi(_, _) => orbiscreen_capture::VirtualOutputLease::none(),
+        }
+    }
+
+    async fn virtual_output_name(&self) -> Option<String> {
+        match self {
+            FrameSource::WlrVirtual { output, .. } => Some(output.name().to_string()),
+            FrameSource::Capture(capture) => capture.virtual_output_name().await,
+            FrameSource::Evdi(_, _) => None,
         }
     }
 }
@@ -1108,14 +1129,28 @@ async fn try_capture_step(
             Ok(FrameSource::Capture(capture))
         }
         CaptureStep::KwinVirtual => {
-            let capture = CaptureSession::open_with_preference(
-                spec.width,
-                spec.height,
-                CapturePreference::KwinVirtual,
-            )
-            .await?;
-            info!(backend = ?capture.backend(), "Capture backend open");
-            Ok(FrameSource::Capture(capture))
+            let mut last_err: Option<DynError> = None;
+            for attempt in 1..=3 {
+                match CaptureSession::open_with_preference(
+                    spec.width,
+                    spec.height,
+                    CapturePreference::KwinVirtual,
+                )
+                .await
+                {
+                    Ok(capture) => {
+                        orbiscreen_capture::kwin_virtual::disable_stale_portal_virtual_outputs();
+                        info!(backend = ?capture.backend(), attempt, "Capture backend open");
+                        return Ok(FrameSource::Capture(capture));
+                    }
+                    Err(e) => {
+                        warn!(attempt, "KWin virtual output failed: {e}");
+                        last_err = Some(e.into());
+                        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+                    }
+                }
+            }
+            Err(last_err.unwrap_or_else(|| "KWin virtual output failed".into()))
         }
         CaptureStep::Portal => {
             let capture = CaptureSession::open_with_preference(
@@ -1253,9 +1288,115 @@ async fn portal_available() -> Option<bool> {
     Some(owned)
 }
 
-async fn bind_kwin_virtual_inputs(target_output: &str) {
+async fn run_idle_virtual_output(
+    mut presence: tokio::sync::watch::Receiver<bool>,
+    lease: orbiscreen_capture::VirtualOutputLease,
+    input_tx: tokio::sync::mpsc::Sender<orbiscreen_transport::IncomingInput>,
+    idr_tx: tokio::sync::mpsc::Sender<()>,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
+) {
+    const IDLE: std::time::Duration = std::time::Duration::from_secs(2);
+    let mut display_up = true;
+    loop {
+        if *shutdown.borrow() {
+            break;
+        }
+        if *presence.borrow_and_update() {
+            if !display_up {
+                display_up =
+                    restore_virtual_output(&lease, &idr_tx, &mut presence, &mut shutdown).await;
+                if !display_up {
+                    tokio::select! {
+                        _ = shutdown.changed() => break,
+                        _ = tokio::time::sleep(IDLE) => {}
+                        res = presence.changed() => {
+                            if res.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+                continue;
+            }
+            tokio::select! {
+                _ = shutdown.changed() => break,
+                res = presence.changed() => {
+                    if res.is_err() {
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+        tokio::select! {
+            _ = shutdown.changed() => break,
+            _ = tokio::time::sleep(IDLE) => {}
+            res = presence.changed() => {
+                if res.is_err() {
+                    break;
+                }
+                continue;
+            }
+        }
+        if *presence.borrow() {
+            continue;
+        }
+        let _ = input_tx.try_send(orbiscreen_transport::IncomingInput::Stylus(
+            orbiscreen_input::StylusEvent::Proximity {},
+        ));
+        if display_up && lease.is_kwin() {
+            lease.park().await;
+            display_up = false;
+        }
+    }
+}
+
+async fn restore_virtual_output(
+    lease: &orbiscreen_capture::VirtualOutputLease,
+    idr_tx: &tokio::sync::mpsc::Sender<()>,
+    presence: &mut tokio::sync::watch::Receiver<bool>,
+    shutdown: &mut tokio::sync::watch::Receiver<bool>,
+) -> bool {
+    const ATTEMPTS: u32 = 3;
+    const BACKOFF: std::time::Duration = std::time::Duration::from_millis(400);
+    for attempt in 1..=ATTEMPTS {
+        match lease.unpark().await {
+            Ok(true) => {
+                if let Some(name) = lease.connector_name().await {
+                    bind_kwin_virtual_inputs(name).await;
+                }
+                let _ = idr_tx.try_send(());
+                return true;
+            }
+            Ok(false) => return true,
+            Err(e) => {
+                warn!(attempt, "could not restore virtual output: {e}");
+                if attempt == ATTEMPTS {
+                    return false;
+                }
+                tokio::select! {
+                    _ = shutdown.changed() => return false,
+                    _ = tokio::time::sleep(BACKOFF) => {}
+                    res = presence.changed() => {
+                        if res.is_err() || !*presence.borrow() {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+async fn bind_kwin_virtual_inputs(preferred_output: String) {
     for delay_ms in [250, 500, 1000, 2000] {
         tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+        let Some(target_output) = orbiscreen_capture::kwin_virtual::preferred_tablet_output(Some(
+            preferred_output.as_str(),
+        )) else {
+            continue;
+        };
         if let Ok(conn) = zbus::Connection::session().await {
             let mut bound = 0;
             for idx in 0..64 {
@@ -1270,9 +1411,22 @@ async fn bind_kwin_virtual_inputs(target_output: &str) {
                 {
                     if let Ok(name) = proxy.get_property::<String>("name").await {
                         if name.starts_with("Orbiscreen") {
-                            let _ = proxy
-                                .set_property::<&str>("outputName", target_output)
-                                .await;
+                            if let Err(e) = proxy
+                                .set_property::<&str>("outputName", target_output.as_str())
+                                .await
+                            {
+                                warn!(
+                                    "could not set outputName={target_output} on {path} ({name}): {e}"
+                                );
+                                continue;
+                            }
+                            if let Some(uuid) =
+                                orbiscreen_capture::kwin_virtual::output_uuid(&target_output)
+                            {
+                                let _ = proxy
+                                    .set_property::<&str>("outputUuid", uuid.as_str())
+                                    .await;
+                            }
                             let _ = proxy.set_property::<bool>("mapToWorkspace", false).await;
                             info!(
                                 "bound KWin input device {path} ({name}) to output {target_output}"
@@ -1859,6 +2013,7 @@ async fn run_start(
     let caps = Capabilities::from_env();
     let frame_pool = orbiscreen_core::frame_pool::FramePool::new();
     let mut source = resolve_frame_source(preferred, &caps, spec, &frame_pool).await?;
+    let virtual_output = source.virtual_output_lease();
 
     let actual_dims = source.actual_dimensions();
     info!(
@@ -1867,28 +2022,26 @@ async fn run_start(
         "stream dimensions established from source"
     );
 
-    let captured_output_name = match &source {
-        FrameSource::WlrVirtual { output, .. } => Some(output.name().to_string()),
-        FrameSource::Capture(c) => match c.backend() {
-            CaptureBackend::KwinVirtual => Some("Virtual-ORBISCREEN".to_string()),
-            _ => None,
-        },
-        _ => None,
-    };
+    let captured_output_name = source.virtual_output_name().await;
+    if let Some(name) = captured_output_name.as_deref() {
+        info!(output = %name, "routing tablet input to KWin output");
+    } else if virtual_output.is_kwin() {
+        warn!("no virtual output to pin tablet input to; touch will land on the laptop screens");
+    }
     let target_kwin_output = captured_output_name.clone();
     let (injector_tx, injector_rx) = tokio::sync::oneshot::channel::<InputInjector>();
     let input_spec = VirtualTouchscreenSpec {
         width: spec.width,
         height: spec.height,
-        output_name: captured_output_name,
+        output_name: captured_output_name.clone(),
     };
     tokio::spawn(async move {
         match InputInjector::open_async(input_spec).await {
             Ok(inj) => {
                 info!(backend = ?inj.backend(), "Input injector open");
                 let _ = injector_tx.send(inj);
-                if let Some(out_name) = target_kwin_output {
-                    bind_kwin_virtual_inputs(&out_name).await;
+                if let Some(name) = target_kwin_output {
+                    bind_kwin_virtual_inputs(name).await;
                 }
             }
             Err(e) => {
@@ -2055,6 +2208,9 @@ async fn run_start(
                         }
                     }
                 }
+                SourceOutcome::Parked => {
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
                 SourceOutcome::Retryable(e) => {
                     if source.is_ended() {
                         error!("capture source ended terminally ({e}); stopping capture pump");
@@ -2090,6 +2246,17 @@ async fn run_start(
     });
 
     let (input_tx, mut input_rx) = mpsc::channel::<orbiscreen_transport::IncomingInput>(1024);
+    {
+        let presence = stats.subscribe_presence();
+        let idle_input = input_tx.clone();
+        let idle_idr = idr_tx.clone();
+        let idle_shutdown = shutdown_rx.clone();
+        let idle_lease = virtual_output;
+        tokio::spawn(async move {
+            run_idle_virtual_output(presence, idle_lease, idle_input, idle_idr, idle_shutdown)
+                .await;
+        });
+    }
     let input_pump = tokio::spawn(async move {
         use orbiscreen_input::PointerEvent;
         use orbiscreen_transport::IncomingInput;

--- a/crates/orbiscreen-input/src/lib.rs
+++ b/crates/orbiscreen-input/src/lib.rs
@@ -251,6 +251,11 @@ impl InputInjector {
             },
         }
     }
+
+    pub async fn release_tools(&mut self) -> Result<(), InputError> {
+        self.fallback_touch_down = false;
+        self.inject_stylus(StylusEvent::Proximity {}).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/orbiscreen-input/src/x11.rs
+++ b/crates/orbiscreen-input/src/x11.rs
@@ -268,6 +268,9 @@ impl UinputInjector {
         if becoming_active {
             self.touch_slot_active[slot] = true;
             self.touch_active_count = self.touch_active_count.saturating_add(1);
+            if self.touch_active_count == 1 {
+                self.release_tools()?;
+            }
         } else if becoming_idle {
             self.touch_slot_active[slot] = false;
             self.touch_active_count = self.touch_active_count.saturating_sub(1);
@@ -302,9 +305,27 @@ impl UinputInjector {
         Ok(())
     }
 
+    pub fn release_tools(&mut self) -> Result<(), InputError> {
+        self.button_1_pressed = false;
+        let xi = self.cursor_x.round() as i32;
+        let yi = self.cursor_y.round() as i32;
+        let events = vec![
+            AbsEvent::new(Abs::X, xi).into(),
+            AbsEvent::new(Abs::Y, yi).into(),
+            AbsEvent::new(Abs::PRESSURE, 0).into(),
+            KEv::new(Key::BTN_TOUCH, KeyState::RELEASED).into(),
+            KEv::new(Key::BTN_STYLUS, KeyState::RELEASED).into(),
+            KEv::new(Key::BTN_STYLUS2, KeyState::RELEASED).into(),
+            KEv::new(Key::BTN_TOOL_PEN, KeyState::RELEASED).into(),
+            SynEvent::new(Syn::REPORT).into(),
+        ];
+        self.tablet.write_events(&events)?;
+        Ok(())
+    }
+
     pub fn inject_stylus(&mut self, event: StylusEvent) -> Result<(), InputError> {
         let (x, y, pressure, tilt) = match event {
-            StylusEvent::Proximity {} => return Ok(()),
+            StylusEvent::Proximity {} => return self.release_tools(),
             StylusEvent::Pressure { x, y, pressure } => (x, y, pressure, None),
             StylusEvent::Tilt {
                 x,

--- a/crates/orbiscreen-transport/Cargo.toml
+++ b/crates/orbiscreen-transport/Cargo.toml
@@ -28,6 +28,7 @@ tracing = { workspace = true }
 tower-http = { workspace = true }
 hostname = { workspace = true }
 orbiscreen-input = { path = "../orbiscreen-input" }
+libc = { workspace = true }
 tokio-stream = { workspace = true }
 gstreamer = { workspace = true }
 gstreamer-app = { workspace = true }

--- a/crates/orbiscreen-transport/src/lib.rs
+++ b/crates/orbiscreen-transport/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod adb;
 pub mod aoa;
 pub mod mdns;
+pub mod udp_stream;
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -55,13 +56,28 @@ pub struct ServerConfig {
     pub client_web_dir: PathBuf,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Stats {
     frames_forwarded: AtomicU64,
     active_clients: AtomicUsize,
     total_clients: AtomicU64,
     auth_failures: AtomicU64,
     usb_devices: AtomicUsize,
+    presence: tokio::sync::watch::Sender<bool>,
+}
+
+impl Default for Stats {
+    fn default() -> Self {
+        let (presence, _) = tokio::sync::watch::channel(false);
+        Self {
+            frames_forwarded: AtomicU64::new(0),
+            active_clients: AtomicUsize::new(0),
+            total_clients: AtomicU64::new(0),
+            auth_failures: AtomicU64::new(0),
+            usb_devices: AtomicUsize::new(0),
+            presence,
+        }
+    }
 }
 
 impl Stats {
@@ -97,13 +113,33 @@ impl Stats {
         self.usb_devices.store(count, Ordering::Relaxed);
     }
 
+    pub fn subscribe_presence(&self) -> tokio::sync::watch::Receiver<bool> {
+        self.presence.subscribe()
+    }
+
     pub fn client_started(&self) {
-        self.active_clients.fetch_add(1, Ordering::Relaxed);
+        let prev = self.active_clients.fetch_add(1, Ordering::Relaxed);
         self.total_clients.fetch_add(1, Ordering::Relaxed);
+        if prev == 0 {
+            let _ = self.presence.send(true);
+        }
     }
 
     pub fn client_stopped(&self) {
-        self.active_clients.fetch_sub(1, Ordering::Relaxed);
+        loop {
+            let cur = self.active_clients.load(Ordering::Relaxed);
+            let next = cur.saturating_sub(1);
+            if self
+                .active_clients
+                .compare_exchange(cur, next, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                if cur == 1 {
+                    let _ = self.presence.send(false);
+                }
+                break;
+            }
+        }
     }
 }
 
@@ -123,7 +159,7 @@ pub fn generate_token() -> String {
     URL_SAFE_NO_PAD.encode(bytes)
 }
 
-fn token_eq(a: &str, b: &str) -> bool {
+pub(crate) fn token_eq(a: &str, b: &str) -> bool {
     let ab = a.as_bytes();
     let bb = b.as_bytes();
     let max_len = ab.len().max(bb.len());
@@ -201,6 +237,25 @@ impl Transport {
             .map(|a| a.to_string())
             .unwrap_or_else(|_| "?".into());
         info!("orbiscreen transport listening on http://{local}");
+
+        let udp_port = udp_stream::default_udp_port(self.cfg.signaling_port);
+        let udp_video = state.video_tx.subscribe();
+        let udp_idr = state.idr_tx.clone();
+        let udp_stats = state.stats.clone();
+        let udp_token = state.token.clone();
+        let udp_shutdown = shutdown_rx.clone();
+        tokio::spawn(async move {
+            udp_stream::run_udp_hub(
+                udp_port,
+                udp_token,
+                udp_video,
+                udp_idr,
+                udp_stats,
+                udp_shutdown,
+                udp_stream::UdpLimits::from_env(),
+            )
+            .await;
+        });
 
         let aoa_port = self.cfg.signaling_port;
         let aoa_active = Arc::new(AtomicUsize::new(0));
@@ -380,6 +435,8 @@ async fn api_info(State(state): State<AppState>) -> impl IntoResponse {
         "refresh_hz": state.refresh_hz,
         "encoder": state.encoder_kind,
         "version": state.version,
+        "udp_port": udp_stream::default_udp_port(state.config.signaling_port),
+        "transport": ["http-mpegts", "udp-annexb"],
     });
     Json(envelope)
 }
@@ -875,6 +932,14 @@ mod tests {
         assert_eq!(stats.active_clients(), 1);
         assert_eq!(stats.total_clients(), 2);
         drop(ClientGuard(Arc::clone(&stats)));
+        assert_eq!(stats.active_clients(), 0);
+        let presence = stats.subscribe_presence();
+        assert!(!*presence.borrow());
+        stats.client_started();
+        assert!(*stats.subscribe_presence().borrow());
+        stats.client_stopped();
+        assert!(!*stats.subscribe_presence().borrow());
+        stats.client_stopped();
         assert_eq!(stats.active_clients(), 0);
     }
 

--- a/crates/orbiscreen-transport/src/udp_stream.rs
+++ b/crates/orbiscreen-transport/src/udp_stream.rs
@@ -1,0 +1,1003 @@
+// Orbiscreen - udp_stream.rs (GPL-3.0-or-later)
+// https://github.com/shadow-x78/orbiscreen
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use rand::Rng;
+use tokio::net::UdpSocket;
+use tokio::sync::broadcast;
+use tracing::{debug, info, warn};
+
+use super::H264Packet;
+
+pub const MAGIC: &[u8; 4] = b"ORB1";
+pub const TYPE_VIDEO: u8 = 1;
+pub const TYPE_HELLO: u8 = 2;
+pub const TYPE_HELLO_ACK: u8 = 3;
+pub const TYPE_PING: u8 = 4;
+pub const TYPE_PONG: u8 = 5;
+pub const TYPE_IDR: u8 = 6;
+pub const TYPE_PROBE: u8 = 7;
+pub const TYPE_PROBE_ACK: u8 = 8;
+pub const TYPE_PMTU: u8 = 9;
+pub const VIDEO_HEADER_LEN: usize = 28;
+pub const PROBE_HEADER_LEN: usize = 7;
+pub const MIN_DATAGRAM: usize = 576;
+pub const BASE_DATAGRAM: usize = 1200;
+pub const DEFAULT_MAX_DATAGRAM: usize = 1472;
+pub const MAX_PAYLOAD: usize = BASE_DATAGRAM - VIDEO_HEADER_LEN;
+const CLIENT_TTL: Duration = Duration::from_secs(5);
+const PROBE_TIMEOUT: Duration = Duration::from_millis(250);
+const MAX_PROBE_ATTEMPTS: u8 = 3;
+const PROBE_STEP: usize = 16;
+
+pub fn default_udp_port(signaling_port: u16) -> u16 {
+    signaling_port.saturating_add(1)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UdpLimits {
+    pub max_datagram: usize,
+    pub drop_above: Option<usize>,
+    pub loss_pct: u8,
+}
+
+impl Default for UdpLimits {
+    fn default() -> Self {
+        Self {
+            max_datagram: DEFAULT_MAX_DATAGRAM,
+            drop_above: None,
+            loss_pct: 0,
+        }
+    }
+}
+
+impl UdpLimits {
+    pub fn from_env() -> Self {
+        let max_datagram = parse_env_usize("ORBISCREEN_UDP_MAX_DATAGRAM")
+            .unwrap_or(DEFAULT_MAX_DATAGRAM)
+            .clamp(MIN_DATAGRAM, 65_507);
+        let drop_above =
+            parse_env_usize("ORBISCREEN_UDP_DROP_ABOVE").map(|n| n.clamp(MIN_DATAGRAM, 65_507));
+        let loss_pct = parse_env_usize("ORBISCREEN_UDP_LOSS_PCT")
+            .unwrap_or(0)
+            .min(90) as u8;
+        Self {
+            max_datagram,
+            drop_above,
+            loss_pct,
+        }
+    }
+}
+
+fn parse_env_usize(name: &str) -> Option<usize> {
+    std::env::var(name).ok()?.parse().ok()
+}
+
+#[derive(Debug, Clone)]
+pub struct PmtuSearch {
+    low: usize,
+    high: usize,
+    probe: Option<usize>,
+    attempts: u8,
+}
+
+impl PmtuSearch {
+    pub fn new(max_datagram: usize) -> Self {
+        let high = max_datagram.clamp(MIN_DATAGRAM, 65_507);
+        let low = BASE_DATAGRAM.min(high).max(MIN_DATAGRAM);
+        Self::from_range(low, high)
+    }
+
+    pub fn from_min(max_datagram: usize) -> Self {
+        let high = max_datagram.clamp(MIN_DATAGRAM, 65_507);
+        Self::from_range(MIN_DATAGRAM.min(high), high)
+    }
+
+    fn from_range(low: usize, high: usize) -> Self {
+        let mut search = Self {
+            low,
+            high: high.max(low),
+            probe: None,
+            attempts: 0,
+        };
+        search.arm();
+        search
+    }
+
+    pub fn confirmed(&self) -> usize {
+        self.low
+    }
+
+    pub fn video_payload(&self) -> usize {
+        self.low.saturating_sub(VIDEO_HEADER_LEN).max(1)
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.probe.is_none()
+    }
+
+    pub fn current_probe(&self) -> Option<usize> {
+        self.probe
+    }
+
+    fn raise(&mut self, size: usize) {
+        if size > self.low && size <= self.high {
+            self.low = size;
+        }
+    }
+
+    pub fn on_ack(&mut self, recv: usize) {
+        let Some(probe) = self.probe else {
+            return;
+        };
+        if recv < probe {
+            self.raise(recv);
+            return;
+        }
+        self.low = probe;
+        self.attempts = 0;
+        self.arm();
+    }
+
+    pub fn on_timeout(&mut self) {
+        if self.probe.is_none() {
+            return;
+        }
+        self.attempts = self.attempts.saturating_add(1);
+        if self.attempts >= MAX_PROBE_ATTEMPTS {
+            self.fail();
+        }
+    }
+
+    fn fail(&mut self) {
+        let Some(probe) = self.probe else {
+            return;
+        };
+        if probe <= self.low.saturating_add(PROBE_STEP) {
+            self.high = self.low;
+            self.probe = None;
+            self.attempts = 0;
+            return;
+        }
+        self.high = probe.saturating_sub(1).max(self.low);
+        self.attempts = 0;
+        self.arm();
+    }
+
+    fn arm(&mut self) {
+        if self.low >= self.high {
+            self.probe = None;
+            return;
+        }
+        let span = self.high - self.low;
+        let next = if span <= PROBE_STEP {
+            self.high
+        } else {
+            self.low
+                .saturating_add(span / 2)
+                .max(self.low.saturating_add(PROBE_STEP))
+                .min(self.high)
+        };
+        if next <= self.low {
+            self.probe = None;
+            return;
+        }
+        self.probe = Some(next);
+        self.attempts = 0;
+    }
+}
+
+pub fn now_unix_ns() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0)
+}
+
+pub fn encode_video(
+    seq: u16,
+    frag: u16,
+    frags: u16,
+    is_keyframe: bool,
+    pts_ns: u64,
+    sent_ns: u64,
+    payload: &[u8],
+) -> Vec<u8> {
+    let mut out = Vec::with_capacity(VIDEO_HEADER_LEN + payload.len());
+    out.extend_from_slice(MAGIC);
+    out.push(TYPE_VIDEO);
+    out.push(u8::from(is_keyframe));
+    out.extend_from_slice(&seq.to_le_bytes());
+    out.extend_from_slice(&frag.to_le_bytes());
+    out.extend_from_slice(&frags.to_le_bytes());
+    out.extend_from_slice(&pts_ns.to_le_bytes());
+    out.extend_from_slice(&sent_ns.to_le_bytes());
+    out.extend_from_slice(payload);
+    out
+}
+
+pub fn encode_hello(token: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity(5 + token.len());
+    out.extend_from_slice(MAGIC);
+    out.push(TYPE_HELLO);
+    out.extend_from_slice(token.as_bytes());
+    out
+}
+
+pub fn encode_hello_ack() -> Vec<u8> {
+    let mut out = Vec::with_capacity(5);
+    out.extend_from_slice(MAGIC);
+    out.push(TYPE_HELLO_ACK);
+    out
+}
+
+pub fn encode_ping(t0_ns: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(13);
+    out.extend_from_slice(MAGIC);
+    out.push(TYPE_PING);
+    out.extend_from_slice(&t0_ns.to_le_bytes());
+    out
+}
+
+pub fn encode_pong(t0_ns: u64, host_ns: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(21);
+    out.extend_from_slice(MAGIC);
+    out.push(TYPE_PONG);
+    out.extend_from_slice(&t0_ns.to_le_bytes());
+    out.extend_from_slice(&host_ns.to_le_bytes());
+    out
+}
+
+pub fn encode_idr() -> Vec<u8> {
+    let mut out = Vec::with_capacity(5);
+    out.extend_from_slice(MAGIC);
+    out.push(TYPE_IDR);
+    out
+}
+
+pub fn encode_probe(id: u16, datagram_len: usize) -> Vec<u8> {
+    let len = datagram_len.max(PROBE_HEADER_LEN);
+    let mut out = vec![0u8; len];
+    out[0..4].copy_from_slice(MAGIC);
+    out[4] = TYPE_PROBE;
+    out[5..7].copy_from_slice(&id.to_le_bytes());
+    out
+}
+
+pub fn encode_probe_ack(id: u16, recv_len: u16) -> Vec<u8> {
+    let mut out = Vec::with_capacity(9);
+    out.extend_from_slice(MAGIC);
+    out.push(TYPE_PROBE_ACK);
+    out.extend_from_slice(&id.to_le_bytes());
+    out.extend_from_slice(&recv_len.to_le_bytes());
+    out
+}
+
+pub fn encode_pmtu(datagram_len: u16) -> Vec<u8> {
+    let mut out = Vec::with_capacity(7);
+    out.extend_from_slice(MAGIC);
+    out.push(TYPE_PMTU);
+    out.extend_from_slice(&datagram_len.to_le_bytes());
+    out
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VideoFragment {
+    pub seq: u16,
+    pub frag: u16,
+    pub frags: u16,
+    pub is_keyframe: bool,
+    pub pts_ns: u64,
+    pub sent_ns: u64,
+    pub payload: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Packet {
+    Video(VideoFragment),
+    Hello(String),
+    HelloAck,
+    Ping(u64),
+    Pong { t0_ns: u64, host_ns: u64 },
+    Idr,
+    Probe { id: u16 },
+    ProbeAck { id: u16, recv: u16 },
+    Pmtu(u16),
+}
+
+pub fn parse_packet(buf: &[u8]) -> Option<Packet> {
+    if buf.len() < 5 || buf[0..4] != MAGIC[..] {
+        return None;
+    }
+    match buf[4] {
+        TYPE_VIDEO => {
+            if buf.len() < 28 {
+                return None;
+            }
+            Some(Packet::Video(VideoFragment {
+                is_keyframe: buf[5] != 0,
+                seq: u16::from_le_bytes([buf[6], buf[7]]),
+                frag: u16::from_le_bytes([buf[8], buf[9]]),
+                frags: u16::from_le_bytes([buf[10], buf[11]]),
+                pts_ns: u64::from_le_bytes(buf[12..20].try_into().ok()?),
+                sent_ns: u64::from_le_bytes(buf[20..28].try_into().ok()?),
+                payload: buf[28..].to_vec(),
+            }))
+        }
+        TYPE_HELLO => Some(Packet::Hello(
+            String::from_utf8_lossy(&buf[5..]).trim().to_string(),
+        )),
+        TYPE_HELLO_ACK => Some(Packet::HelloAck),
+        TYPE_PING => {
+            if buf.len() < 13 {
+                return None;
+            }
+            Some(Packet::Ping(u64::from_le_bytes(
+                buf[5..13].try_into().ok()?,
+            )))
+        }
+        TYPE_PONG => {
+            if buf.len() < 21 {
+                return None;
+            }
+            Some(Packet::Pong {
+                t0_ns: u64::from_le_bytes(buf[5..13].try_into().ok()?),
+                host_ns: u64::from_le_bytes(buf[13..21].try_into().ok()?),
+            })
+        }
+        TYPE_IDR => Some(Packet::Idr),
+        TYPE_PROBE => {
+            if buf.len() < PROBE_HEADER_LEN {
+                return None;
+            }
+            Some(Packet::Probe {
+                id: u16::from_le_bytes([buf[5], buf[6]]),
+            })
+        }
+        TYPE_PROBE_ACK => {
+            if buf.len() < 9 {
+                return None;
+            }
+            Some(Packet::ProbeAck {
+                id: u16::from_le_bytes([buf[5], buf[6]]),
+                recv: u16::from_le_bytes([buf[7], buf[8]]),
+            })
+        }
+        TYPE_PMTU => {
+            if buf.len() < 7 {
+                return None;
+            }
+            Some(Packet::Pmtu(u16::from_le_bytes([buf[5], buf[6]])))
+        }
+        _ => None,
+    }
+}
+
+pub fn fragment_video(
+    seq: u16,
+    pkt: &H264Packet,
+    sent_ns: u64,
+    max_payload: usize,
+) -> Vec<Vec<u8>> {
+    if pkt.bytes.is_empty() {
+        return Vec::new();
+    }
+    let chunk = max_payload.max(1);
+    let chunks: Vec<&[u8]> = pkt.bytes.chunks(chunk).collect();
+    let frags = chunks.len() as u16;
+    chunks
+        .into_iter()
+        .enumerate()
+        .map(|(i, chunk)| {
+            encode_video(
+                seq,
+                i as u16,
+                frags,
+                pkt.is_keyframe,
+                pkt.pts_ns,
+                sent_ns,
+                chunk,
+            )
+        })
+        .collect()
+}
+
+struct UdpClient {
+    last_seen: Instant,
+    pmtu: PmtuSearch,
+    probe_id: u16,
+    probe_deadline: Option<Instant>,
+    announced: bool,
+}
+
+fn new_client(limits: UdpLimits) -> UdpClient {
+    let pmtu = if limits.drop_above.is_some() {
+        PmtuSearch::from_min(limits.max_datagram)
+    } else {
+        PmtuSearch::new(limits.max_datagram)
+    };
+    UdpClient {
+        last_seen: Instant::now(),
+        pmtu,
+        probe_id: 0,
+        probe_deadline: None,
+        announced: false,
+    }
+}
+
+fn would_drop(len: usize, drop_above: Option<usize>) -> bool {
+    drop_above.is_some_and(|limit| len > limit)
+}
+
+fn should_lose(loss_pct: u8) -> bool {
+    loss_pct > 0 && rand::rng().random_range(0u8..100) < loss_pct
+}
+
+async fn send_datagram(sock: &UdpSocket, buf: &[u8], addr: SocketAddr, limits: UdpLimits) -> bool {
+    if would_drop(buf.len(), limits.drop_above) || should_lose(limits.loss_pct) {
+        return false;
+    }
+    if let Err(e) = sock.send_to(buf, addr).await {
+        debug!(%addr, "UDP send failed: {e}");
+        return false;
+    }
+    true
+}
+
+async fn send_probe(sock: &UdpSocket, addr: SocketAddr, client: &mut UdpClient, limits: UdpLimits) {
+    let Some(size) = client.pmtu.current_probe() else {
+        return;
+    };
+    if client.probe_id == 0 {
+        client.probe_id = 1;
+    }
+    client.probe_deadline = Some(Instant::now() + PROBE_TIMEOUT);
+    let pkt = encode_probe(client.probe_id, size);
+    let sent = send_datagram(sock, &pkt, addr, limits).await;
+    debug!(
+        %addr,
+        size,
+        id = client.probe_id,
+        sent,
+        "UDP PMTU probe"
+    );
+}
+
+async fn announce_pmtu(
+    sock: &UdpSocket,
+    addr: SocketAddr,
+    client: &mut UdpClient,
+    limits: UdpLimits,
+) {
+    if client.announced || !client.pmtu.is_complete() {
+        return;
+    }
+    client.announced = true;
+    let datagram = client.pmtu.confirmed();
+    let payload = client.pmtu.video_payload();
+    info!(%addr, datagram, payload, "UDP PMTU confirmed");
+    let _ = send_datagram(sock, &encode_pmtu(datagram as u16), addr, limits).await;
+}
+
+fn bump_probe_id(client: &mut UdpClient) {
+    client.probe_id = client.probe_id.wrapping_add(1);
+    if client.probe_id == 0 {
+        client.probe_id = 1;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AckEffect {
+    Ignored,
+    Continue,
+    Completed,
+}
+
+fn apply_probe_ack(client: &mut UdpClient, id: u16, recv: usize) -> AckEffect {
+    if id != client.probe_id || client.pmtu.is_complete() {
+        return AckEffect::Ignored;
+    }
+    let before = client.pmtu.current_probe();
+    client.probe_deadline = None;
+    client.pmtu.on_ack(recv);
+    if client.pmtu.current_probe() != before {
+        bump_probe_id(client);
+    }
+    if client.pmtu.is_complete() {
+        AckEffect::Completed
+    } else {
+        AckEffect::Continue
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn set_dont_fragment(sock: &std::net::UdpSocket) {
+    use std::os::fd::AsRawFd;
+    let fd = sock.as_raw_fd();
+    let val: libc::c_int = libc::IP_PMTUDISC_PROBE;
+    #[allow(unsafe_code)]
+    let rc = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::IPPROTO_IP,
+            libc::IP_MTU_DISCOVER,
+            std::ptr::addr_of!(val).cast(),
+            std::mem::size_of_val(&val) as libc::socklen_t,
+        )
+    };
+    if rc != 0 {
+        warn!(
+            "IP_MTU_DISCOVER PROBE failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+}
+
+fn bind_udp_socket(port: u16) -> std::io::Result<UdpSocket> {
+    let std_sock = std::net::UdpSocket::bind(("0.0.0.0", port))?;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    set_dont_fragment(&std_sock);
+    std_sock.set_nonblocking(true)?;
+    UdpSocket::from_std(std_sock)
+}
+
+pub async fn run_udp_hub(
+    port: u16,
+    token: String,
+    mut video_rx: broadcast::Receiver<H264Packet>,
+    idr_tx: Option<tokio::sync::mpsc::Sender<()>>,
+    stats: std::sync::Arc<super::Stats>,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
+    limits: UdpLimits,
+) {
+    let sock = match bind_udp_socket(port) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("UDP video bind {port} failed: {e}");
+            return;
+        }
+    };
+    info!(
+        max_datagram = limits.max_datagram,
+        drop_above = ?limits.drop_above,
+        loss_pct = limits.loss_pct,
+        "UDP video listening on 0.0.0.0:{port}"
+    );
+    let sock = std::sync::Arc::new(sock);
+    let clients: std::sync::Arc<tokio::sync::Mutex<HashMap<SocketAddr, UdpClient>>> =
+        std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+
+    let recv_sock = sock.clone();
+    let recv_clients = clients.clone();
+    let recv_token = token.clone();
+    let recv_idr = idr_tx.clone();
+    let recv_stats = stats.clone();
+    let recv_limits = limits;
+    let mut recv_shutdown = shutdown.clone();
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 4096];
+        loop {
+            tokio::select! {
+                _ = recv_shutdown.changed() => break,
+                res = recv_sock.recv_from(&mut buf) => {
+                    let Ok((n, addr)) = res else { continue };
+                    handle_incoming(
+                        &buf[..n],
+                        addr,
+                        &recv_token,
+                        &recv_sock,
+                        &recv_clients,
+                        recv_idr.as_ref(),
+                        &recv_stats,
+                        recv_limits,
+                    ).await;
+                }
+            }
+        }
+    });
+
+    let mut seq: u16 = 0;
+    let mut prune = tokio::time::interval(Duration::from_secs(1));
+    let mut probe_tick = tokio::time::interval(Duration::from_millis(20));
+    probe_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            _ = shutdown.changed() => break,
+            _ = prune.tick() => {
+                let mut map = clients.lock().await;
+                let before = map.len();
+                map.retain(|_, c| c.last_seen.elapsed() < CLIENT_TTL);
+                let dropped = before.saturating_sub(map.len());
+                for _ in 0..dropped {
+                    stats.client_stopped();
+                }
+            }
+            _ = probe_tick.tick() => {
+                let now = Instant::now();
+                let mut map = clients.lock().await;
+                for (addr, client) in map.iter_mut() {
+                    let expired = client
+                        .probe_deadline
+                        .is_some_and(|deadline| now >= deadline);
+                    if expired {
+                        let before = client.pmtu.current_probe();
+                        client.probe_deadline = None;
+                        client.pmtu.on_timeout();
+                        if client.pmtu.current_probe() != before {
+                            bump_probe_id(client);
+                        }
+                        if client.pmtu.is_complete() {
+                            announce_pmtu(&sock, *addr, client, limits).await;
+                            request_idr_sender(idr_tx.as_ref());
+                        } else if client.pmtu.current_probe().is_some() {
+                            send_probe(&sock, *addr, client, limits).await;
+                        }
+                    }
+                }
+            }
+            pkt = video_rx.recv() => {
+                let pkt = match pkt {
+                    Ok(p) => p,
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => break,
+                };
+                let targets: Vec<(SocketAddr, usize)> = {
+                    let map = clients.lock().await;
+                    map.iter()
+                        .filter(|(_, c)| c.pmtu.is_complete())
+                        .map(|(addr, c)| (*addr, c.pmtu.video_payload()))
+                        .collect()
+                };
+                if targets.is_empty() {
+                    continue;
+                }
+                seq = seq.wrapping_add(1);
+                let sent_ns = now_unix_ns();
+                for (addr, payload) in targets {
+                    let frames = fragment_video(seq, &pkt, sent_ns, payload);
+                    for frame in &frames {
+                        if !send_datagram(&sock, frame, addr, limits).await {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn handle_incoming(
+    buf: &[u8],
+    addr: SocketAddr,
+    token: &str,
+    sock: &UdpSocket,
+    clients: &tokio::sync::Mutex<HashMap<SocketAddr, UdpClient>>,
+    idr_tx: Option<&tokio::sync::mpsc::Sender<()>>,
+    stats: &super::Stats,
+    limits: UdpLimits,
+) {
+    match parse_packet(buf) {
+        Some(Packet::Hello(got)) => {
+            if !super::token_eq(&got, token) {
+                warn!(%addr, "UDP hello rejected");
+                stats.note_auth_failure();
+                return;
+            }
+            let mut map = clients.lock().await;
+            let joining = !map.contains_key(&addr);
+            let client = map.entry(addr).or_insert_with(|| new_client(limits));
+            client.last_seen = Instant::now();
+            if joining {
+                stats.client_started();
+                info!(
+                    %addr,
+                    start = client.pmtu.confirmed(),
+                    payload = client.pmtu.video_payload(),
+                    "UDP client joined"
+                );
+                request_idr_sender(idr_tx);
+            }
+            let _ = send_datagram(sock, &encode_hello_ack(), addr, limits).await;
+            if joining {
+                if client.pmtu.is_complete() {
+                    announce_pmtu(sock, addr, client, limits).await;
+                } else {
+                    send_probe(sock, addr, client, limits).await;
+                }
+            }
+        }
+        Some(Packet::Ping(t0)) => {
+            touch_client(clients, addr).await;
+            let _ = send_datagram(sock, &encode_pong(t0, now_unix_ns()), addr, limits).await;
+        }
+        Some(Packet::Idr) => {
+            if touch_client(clients, addr).await {
+                request_idr_sender(idr_tx);
+            }
+        }
+        Some(Packet::ProbeAck { id, recv }) => {
+            let mut map = clients.lock().await;
+            let Some(client) = map.get_mut(&addr) else {
+                return;
+            };
+            client.last_seen = Instant::now();
+            let recv = recv as usize;
+            match apply_probe_ack(client, id, recv) {
+                AckEffect::Ignored => {}
+                AckEffect::Completed => {
+                    debug!(
+                        %addr,
+                        recv,
+                        confirmed = client.pmtu.confirmed(),
+                        "UDP PMTU ack"
+                    );
+                    announce_pmtu(sock, addr, client, limits).await;
+                    request_idr_sender(idr_tx);
+                }
+                AckEffect::Continue => {
+                    debug!(
+                        %addr,
+                        recv,
+                        confirmed = client.pmtu.confirmed(),
+                        "UDP PMTU ack"
+                    );
+                    send_probe(sock, addr, client, limits).await;
+                }
+            }
+        }
+        Some(
+            Packet::HelloAck
+            | Packet::Pong { .. }
+            | Packet::Video(_)
+            | Packet::Probe { .. }
+            | Packet::Pmtu(_),
+        ) => {}
+        None => {}
+    }
+}
+
+async fn touch_client(
+    clients: &tokio::sync::Mutex<HashMap<SocketAddr, UdpClient>>,
+    addr: SocketAddr,
+) -> bool {
+    let mut map = clients.lock().await;
+    if let Some(c) = map.get_mut(&addr) {
+        c.last_seen = Instant::now();
+        true
+    } else {
+        false
+    }
+}
+
+fn request_idr_sender(idr_tx: Option<&tokio::sync::mpsc::Sender<()>>) {
+    if let Some(tx) = idr_tx {
+        let _ = tx.try_send(());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn video_roundtrip() {
+        let pkt = H264Packet {
+            bytes: vec![0, 0, 0, 1, 0x65, 1, 2, 3],
+            is_keyframe: true,
+            pts_ns: 42,
+        };
+        let frames = fragment_video(7, &pkt, 99, MAX_PAYLOAD);
+        assert_eq!(frames.len(), 1);
+        match parse_packet(&frames[0]) {
+            Some(Packet::Video(v)) => {
+                assert_eq!(v.seq, 7);
+                assert!(v.is_keyframe);
+                assert_eq!(v.pts_ns, 42);
+                assert_eq!(v.sent_ns, 99);
+                assert_eq!(v.payload, pkt.bytes);
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn fragments_large_au() {
+        let pkt = H264Packet {
+            bytes: vec![7u8; MAX_PAYLOAD + 50],
+            is_keyframe: false,
+            pts_ns: 1,
+        };
+        let frames = fragment_video(1, &pkt, 2, MAX_PAYLOAD);
+        assert_eq!(frames.len(), 2);
+        let a = match parse_packet(&frames[0]) {
+            Some(Packet::Video(v)) => v,
+            _ => panic!(),
+        };
+        let b = match parse_packet(&frames[1]) {
+            Some(Packet::Video(v)) => v,
+            _ => panic!(),
+        };
+        assert_eq!(a.frags, 2);
+        assert_eq!(b.frag, 1);
+        assert_eq!(a.payload.len() + b.payload.len(), pkt.bytes.len());
+    }
+
+    #[test]
+    fn hello_and_control_roundtrip() {
+        let hello = parse_packet(&encode_hello("tok"));
+        assert_eq!(hello, Some(Packet::Hello("tok".into())));
+        assert_eq!(parse_packet(&encode_hello_ack()), Some(Packet::HelloAck));
+        assert_eq!(parse_packet(&encode_idr()), Some(Packet::Idr));
+        match parse_packet(&encode_pong(1, 2)) {
+            Some(Packet::Pong { t0_ns, host_ns }) => {
+                assert_eq!(t0_ns, 1);
+                assert_eq!(host_ns, 2);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn default_port_is_signaling_plus_one() {
+        assert_eq!(default_udp_port(8788), 8789);
+    }
+
+    #[test]
+    fn probe_roundtrip() {
+        let pkt = encode_probe(9, 900);
+        assert_eq!(pkt.len(), 900);
+        assert_eq!(parse_packet(&pkt), Some(Packet::Probe { id: 9 }));
+        assert_eq!(
+            parse_packet(&encode_probe_ack(9, 900)),
+            Some(Packet::ProbeAck { id: 9, recv: 900 })
+        );
+        assert_eq!(parse_packet(&encode_pmtu(900)), Some(Packet::Pmtu(900)));
+    }
+
+    fn drive_search(mut search: PmtuSearch, path_mtu: usize) -> usize {
+        let mut steps = 0;
+        while !search.is_complete() {
+            steps += 1;
+            assert!(steps < 80, "search did not converge");
+            let probe = search.current_probe().expect("probe while incomplete");
+            if probe <= path_mtu {
+                search.on_ack(probe);
+            } else {
+                search.on_timeout();
+            }
+        }
+        search.confirmed()
+    }
+
+    #[test]
+    fn pmtu_reaches_ceiling_when_path_is_open() {
+        let found = drive_search(PmtuSearch::from_min(DEFAULT_MAX_DATAGRAM), 10_000);
+        assert_eq!(found, DEFAULT_MAX_DATAGRAM);
+    }
+
+    #[test]
+    fn pmtu_finds_artificial_limits() {
+        for limit in [700usize, 900, 1200, 1400] {
+            let found = drive_search(PmtuSearch::from_min(DEFAULT_MAX_DATAGRAM), limit);
+            assert!(
+                found <= limit,
+                "limit {limit}: found {found} above path MTU"
+            );
+            assert!(
+                limit - found <= PROBE_STEP,
+                "limit {limit}: found {found}, farther than {PROBE_STEP}"
+            );
+        }
+    }
+
+    #[test]
+    fn zero_loss_pct_never_drops() {
+        for _ in 0..200 {
+            assert!(!should_lose(0));
+        }
+    }
+
+    #[test]
+    fn complete_search_ignores_further_acks() {
+        let mut search = PmtuSearch::new(BASE_DATAGRAM);
+        assert!(search.is_complete());
+        search.on_ack(DEFAULT_MAX_DATAGRAM);
+        assert_eq!(search.confirmed(), BASE_DATAGRAM);
+    }
+
+    #[test]
+    fn mismatched_or_late_probe_ack_is_ignored() {
+        let mut client = new_client(UdpLimits::default());
+        client.probe_id = 3;
+        let before = client.pmtu.confirmed();
+        assert_eq!(
+            apply_probe_ack(&mut client, 2, DEFAULT_MAX_DATAGRAM),
+            AckEffect::Ignored
+        );
+        assert_eq!(client.pmtu.confirmed(), before);
+
+        client.pmtu = PmtuSearch::new(BASE_DATAGRAM);
+        client.probe_id = 5;
+        assert!(client.pmtu.is_complete());
+        assert_eq!(
+            apply_probe_ack(&mut client, 5, DEFAULT_MAX_DATAGRAM),
+            AckEffect::Ignored
+        );
+        assert_eq!(client.pmtu.confirmed(), BASE_DATAGRAM);
+    }
+
+    #[test]
+    fn production_search_starts_at_base() {
+        let search = PmtuSearch::new(DEFAULT_MAX_DATAGRAM);
+        assert_eq!(search.confirmed(), BASE_DATAGRAM);
+        assert_eq!(search.video_payload(), BASE_DATAGRAM - VIDEO_HEADER_LEN);
+        assert!(!search.is_complete());
+    }
+
+    #[tokio::test]
+    async fn loopback_discovers_drop_above() {
+        let drop_above = 900usize;
+        let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let client = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let client_addr = client.local_addr().unwrap();
+
+        let client_task = tokio::spawn(async move {
+            let mut buf = vec![0u8; 2048];
+            let mut confirmed = None;
+            while confirmed.is_none() {
+                let (n, addr) = client.recv_from(&mut buf).await.unwrap();
+                match parse_packet(&buf[..n]) {
+                    Some(Packet::Probe { id }) => {
+                        if n <= drop_above {
+                            let _ = client.send_to(&encode_probe_ack(id, n as u16), addr).await;
+                        }
+                    }
+                    Some(Packet::Pmtu(size)) => confirmed = Some(size),
+                    _ => {}
+                }
+            }
+            confirmed
+        });
+
+        let mut search = PmtuSearch::from_min(DEFAULT_MAX_DATAGRAM);
+        let mut id = 0u16;
+        let mut buf = vec![0u8; 2048];
+        let mut steps = 0;
+        while !search.is_complete() {
+            steps += 1;
+            assert!(steps < 80, "loopback search did not converge");
+            let size = search.current_probe().unwrap();
+            id = id.wrapping_add(1);
+            let pkt = encode_probe(id, size);
+            if pkt.len() > drop_above {
+                search.on_timeout();
+                continue;
+            }
+            server.send_to(&pkt, client_addr).await.unwrap();
+            match tokio::time::timeout(Duration::from_millis(200), server.recv_from(&mut buf)).await
+            {
+                Ok(Ok((n, _))) => match parse_packet(&buf[..n]) {
+                    Some(Packet::ProbeAck { id: ack_id, recv }) if ack_id == id => {
+                        search.on_ack(recv as usize)
+                    }
+                    _ => search.on_timeout(),
+                },
+                _ => search.on_timeout(),
+            }
+        }
+        server
+            .send_to(&encode_pmtu(search.confirmed() as u16), client_addr)
+            .await
+            .unwrap();
+        let client_seen = tokio::time::timeout(Duration::from_secs(1), client_task)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(client_seen, Some(search.confirmed() as u16));
+        assert!(search.confirmed() <= drop_above);
+        assert!(drop_above - search.confirmed() <= PROBE_STEP);
+    }
+}

--- a/crates/orbiscreen-transport/src/udp_stream.rs
+++ b/crates/orbiscreen-transport/src/udp_stream.rs
@@ -584,16 +584,15 @@ pub async fn run_udp_hub(
                 _ = recv_shutdown.changed() => break,
                 res = recv_sock.recv_from(&mut buf) => {
                     let Ok((n, addr)) = res else { continue };
-                    handle_incoming(
-                        &buf[..n],
-                        addr,
-                        &recv_token,
-                        &recv_sock,
-                        &recv_clients,
-                        recv_idr.as_ref(),
-                        &recv_stats,
-                        recv_limits,
-                    ).await;
+                    let ctx = IncomingCtx {
+                        token: &recv_token,
+                        sock: &recv_sock,
+                        clients: &recv_clients,
+                        idr_tx: recv_idr.as_ref(),
+                        stats: &recv_stats,
+                        limits: recv_limits,
+                    };
+                    handle_incoming(&buf[..n], addr, &ctx).await;
                 }
             }
         }
@@ -669,57 +668,59 @@ pub async fn run_udp_hub(
     }
 }
 
-async fn handle_incoming(
-    buf: &[u8],
-    addr: SocketAddr,
-    token: &str,
-    sock: &UdpSocket,
-    clients: &tokio::sync::Mutex<HashMap<SocketAddr, UdpClient>>,
-    idr_tx: Option<&tokio::sync::mpsc::Sender<()>>,
-    stats: &super::Stats,
+#[allow(missing_debug_implementations)]
+struct IncomingCtx<'a> {
+    token: &'a str,
+    sock: &'a UdpSocket,
+    clients: &'a tokio::sync::Mutex<HashMap<SocketAddr, UdpClient>>,
+    idr_tx: Option<&'a tokio::sync::mpsc::Sender<()>>,
+    stats: &'a super::Stats,
     limits: UdpLimits,
-) {
+}
+
+async fn handle_incoming(buf: &[u8], addr: SocketAddr, ctx: &IncomingCtx<'_>) {
     match parse_packet(buf) {
         Some(Packet::Hello(got)) => {
-            if !super::token_eq(&got, token) {
+            if !super::token_eq(&got, ctx.token) {
                 warn!(%addr, "UDP hello rejected");
-                stats.note_auth_failure();
+                ctx.stats.note_auth_failure();
                 return;
             }
-            let mut map = clients.lock().await;
+            let mut map = ctx.clients.lock().await;
             let joining = !map.contains_key(&addr);
-            let client = map.entry(addr).or_insert_with(|| new_client(limits));
+            let client = map.entry(addr).or_insert_with(|| new_client(ctx.limits));
             client.last_seen = Instant::now();
             if joining {
-                stats.client_started();
+                ctx.stats.client_started();
                 info!(
                     %addr,
                     start = client.pmtu.confirmed(),
                     payload = client.pmtu.video_payload(),
                     "UDP client joined"
                 );
-                request_idr_sender(idr_tx);
+                request_idr_sender(ctx.idr_tx);
             }
-            let _ = send_datagram(sock, &encode_hello_ack(), addr, limits).await;
+            let _ = send_datagram(ctx.sock, &encode_hello_ack(), addr, ctx.limits).await;
             if joining {
                 if client.pmtu.is_complete() {
-                    announce_pmtu(sock, addr, client, limits).await;
+                    announce_pmtu(ctx.sock, addr, client, ctx.limits).await;
                 } else {
-                    send_probe(sock, addr, client, limits).await;
+                    send_probe(ctx.sock, addr, client, ctx.limits).await;
                 }
             }
         }
         Some(Packet::Ping(t0)) => {
-            touch_client(clients, addr).await;
-            let _ = send_datagram(sock, &encode_pong(t0, now_unix_ns()), addr, limits).await;
+            touch_client(ctx.clients, addr).await;
+            let _ =
+                send_datagram(ctx.sock, &encode_pong(t0, now_unix_ns()), addr, ctx.limits).await;
         }
         Some(Packet::Idr) => {
-            if touch_client(clients, addr).await {
-                request_idr_sender(idr_tx);
+            if touch_client(ctx.clients, addr).await {
+                request_idr_sender(ctx.idr_tx);
             }
         }
         Some(Packet::ProbeAck { id, recv }) => {
-            let mut map = clients.lock().await;
+            let mut map = ctx.clients.lock().await;
             let Some(client) = map.get_mut(&addr) else {
                 return;
             };
@@ -734,8 +735,8 @@ async fn handle_incoming(
                         confirmed = client.pmtu.confirmed(),
                         "UDP PMTU ack"
                     );
-                    announce_pmtu(sock, addr, client, limits).await;
-                    request_idr_sender(idr_tx);
+                    announce_pmtu(ctx.sock, addr, client, ctx.limits).await;
+                    request_idr_sender(ctx.idr_tx);
                 }
                 AckEffect::Continue => {
                     debug!(
@@ -744,7 +745,7 @@ async fn handle_incoming(
                         confirmed = client.pmtu.confirmed(),
                         "UDP PMTU ack"
                     );
-                    send_probe(sock, addr, client, limits).await;
+                    send_probe(ctx.sock, addr, client, ctx.limits).await;
                 }
             }
         }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,6 +34,7 @@ graph TD
         D -->|"GStreamer HW/SW Encode"| E["H.264 AU stream"]
         E --> F["orbiscreen-transport"]
         F -->|"MPEG-TS HTTP /stream"| G["Network / USB"]
+        F -->|"UDP Annex-B (udp_port)"| G
         F -->|"mDNS _orbiscreen._tcp."| G
         F -->|"GET /api/info"| G
         F -->|"POST /api/control"| G
@@ -45,9 +46,11 @@ graph TD
         W -->|"POST /input"| F
         G -->|"NSD discovery + token"| H["Android DiscoveryService"]
         H -->|"onConnect"| J["StreamViewModel"]
-        J -->|"PlayerHolder.build"| K["OkHttpDataSource"]
+        J -->|"UDP when advertised"| U["UdpPlayer + MediaCodec"]
+        J -->|"HTTP fallback"| K["OkHttpDataSource"]
         K -->|"MPEG-TS + Bearer token"| L["ExoPlayer + MediaCodec"]
-        L -->|"Touch"| N["InputDispatcher"]
+        U -->|"Touch"| N["InputDispatcher"]
+        L -->|"Touch"| N
         N -->|"POST /input + Bearer token"| F
         J -->|"POST /api/control"| F
     end
@@ -64,7 +67,7 @@ graph TD
 | `orbiscreen-capture` | Wayland Portal (ashpd) & X11 (x11rb) capture engines: **fallback source only** | `ashpd`, `x11rb` |
 | `orbiscreen-encode` | Hardware & software H.264 encoding pipelines | `gstreamer`, `gstreamer-app` |
 | `orbiscreen-input` | Reverse touch, stylus, and keyboard injection (uinput) | `evdev`, `ashpd` |
-| `orbiscreen-transport` | Axum HTTP `/stream` + token auth, mDNS, ADB reverse, `/api/info`, `/api/control`, `/health` | `axum`, `gstreamer`, `tokio`, `rand`, `base64` |
+| `orbiscreen-transport` | Axum HTTP `/stream` + token auth, UDP Annex-B (`udp_port`), mDNS, ADB reverse, `/api/info`, `/api/control`, `/health` | `axum`, `gstreamer`, `tokio`, `rand`, `base64` |
 | `orbiscreen-daemon` | Main daemon binary, systemd integration & live D-Bus service | `zbus`, `clap`, `tokio` |
 
 ---

--- a/docs/ARCHITECTURE_AR.md
+++ b/docs/ARCHITECTURE_AR.md
@@ -34,6 +34,7 @@ graph TD
         D -->|"ترميز GStreamer عتادي/برمجي"| E["بث تدفق H.264 AU"]
         E --> F["orbiscreen-transport (النقل والشبكة)"]
         F -->|"بث MPEG-TS HTTP عبر مسار /stream"| G["الشبكة / وصلة USB"]
+        F -->|"UDP Annex-B (udp_port)"| G
         F -->|"استكشاف mDNS _orbiscreen._tcp."| G
         F -->|"معلومات العرض GET /api/info"| G
         F -->|"أوامر التحكم POST /api/control"| G
@@ -66,7 +67,7 @@ graph TD
 | `orbiscreen-capture` | محركات الالتقاط عبر &rlm;Wayland Portal (ashpd)&rlm; و &rlm;X11 (x11rb) | `ashpd`، `x11rb` |
 | `orbiscreen-encode` | خطوط أنابيب ترميز &rlm;H.264&rlm; عتادية وبرمجية | `gstreamer`، `gstreamer-app` |
 | `orbiscreen-input` | حقن اللمس العكسي والقلم ولوحة المفاتيح | `evdevil`، `nix` |
-| `orbiscreen-transport` | خادم &rlm;Axum HTTP&rlm; على مسار `/stream`، واكتشاف &rlm;mDNS&rlm;، ونفق &rlm;ADB reverse&rlm;، ونقاط `/api/*` و `/health` | `axum`، `gstreamer`، `tokio` |
+| `orbiscreen-transport` | خادم &rlm;Axum HTTP&rlm; على مسار `/stream`، وUDP بنمط Annex-B (`udp_port`)، واكتشاف &rlm;mDNS&rlm;، ونفق &rlm;ADB reverse&rlm;، ونقاط `/api/*` و `/health` | `axum`، `gstreamer`، `tokio` |
 | `orbiscreen-daemon` | ثنائي الـ &rlm;daemon&rlm; الرئيسي، تكامل &rlm;systemd&rlm; وخدمة &rlm;D-Bus | `zbus`، `clap`، `tokio` |
 
 </div>

--- a/docs/UDP_TRANSPORT.md
+++ b/docs/UDP_TRANSPORT.md
@@ -1,0 +1,74 @@
+<div align="center">
+
+# UDP Annex-B Transport - Orbiscreen
+
+[![Version](https://img.shields.io/badge/version-0.24.0-2563eb?style=flat-square&logo=semver)](../CHANGELOG.md)
+[![License](https://img.shields.io/badge/license-GPL--3.0-dc2626?style=flat-square)](../LICENSE)
+![Rust](https://img.shields.io/badge/rust-1.75%2B-16a34a?style=flat-square&logo=rust)
+![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20Android-9333ea?style=flat-square&logo=linux)
+
+</div>
+
+---
+
+Android streams H.264 access units over UDP. HTTP MPEG-TS on `/stream` stays for the web client and as fallback.
+
+The daemon advertises `udp_port` on `GET /api/info` (`signaling_port + 1`, default **8789**). Android uses UDP when that port is set and the host is not `127.0.0.1` / `localhost`. USB/AOA cannot carry raw UDP (`adb reverse` is TCP-only), so those paths stay on HTTP.
+
+## Session
+
+1. Client sends **Hello** with the session token (same constant-time compare as HTTP Bearer).
+2. Host replies **Hello-Ack** and starts DPLPMTUD. The client waits 1.5 s and treats probes that arrive before the ack as control, not failure.
+3. Video is withheld until a datagram size is confirmed. Fragments then use that size.
+4. Client pings every 500 ms. Missing all packets for 4 s ends the UDP session.
+5. A gap or a lost fragment holds P-frames until the next IDR. The client sends **IDR**; the host reuses `POST /api/control` `action: idr`.
+6. Idle clients expire after 5 s without a packet. The last HTTP/UDP client also parks the KWin virtual output.
+
+## Packet format
+
+Every datagram starts with magic `ORB1` and a type byte. Multi-byte fields are little-endian.
+
+| Type | Name | Layout after magic+type |
+|------|------|-------------------------|
+| 1 | Video | `key u8`, `seq u16`, `frag u16`, `frags u16`, `pts_ns u64`, `sent_ns u64`, payload (28-byte header) |
+| 2 | Hello | UTF-8 token |
+| 3 | Hello-Ack | empty |
+| 4 | Ping | `t0_ns u64` |
+| 5 | Pong | `t0_ns u64`, `host_ns u64` |
+| 6 | IDR | empty |
+| 7 | Probe | `id u16`, zero pad to the probe size |
+| 8 | Probe-Ack | `id u16`, `recv u16` (bytes received) |
+| 9 | PMTU | `datagram u16` (confirmed size) |
+
+## DPLPMTUD
+
+Search starts at 1200 bytes (576 when `ORBISCREEN_UDP_DROP_ABOVE` is set) and walks up to 1472, or `ORBISCREEN_UDP_MAX_DATAGRAM`. Each probe is padded to the candidate size. Three 250 ms timeouts fail a candidate. Late acks whose id is not the in-flight probe are ignored after the search completes.
+
+The host socket sets `IP_PMTUDISC_PROBE` so a too-large datagram is dropped instead of IP-fragmented.
+
+A 2560×1600 IDR is many fragments. A few percent datagram loss often means no complete keyframe arrives, so the surface stays on the last good frame (or black) while the session stays up. That is the hold-until-IDR rule, not a disconnect.
+
+## Android client
+
+`UdpPlayer` decodes with MediaCodec onto a `SurfaceView` letterboxed to the same content rect as touch mapping (`scaleMode` FIT by default). The stream menu shows send-to-assemble delay as `delay Nms`.
+
+## Latency
+
+`delay` is host-send to client-assemble for one access unit (clock-adjusted `sent_ns`). It does not include capture, encode, or MediaCodec/display after assemble.
+
+On a Samsung Galaxy Tab S5e (SM-T725) over 5 GHz Wi-Fi, 2560×1600@60, VA-API `vah264enc`:
+
+| Path | What is measured | Typical |
+|------|------------------|---------|
+| Previous (HTTP MPEG-TS + ExoPlayer) | ExoPlayer live offset target (min 8, max 48) | **24 ms** |
+| This transport (UDP Annex-B + MediaCodec) | send-to-assemble `delay` | **2–4 ms** (usually 2–3 ms) |
+
+That is about **10×** less player/transport delay than the HTTP live-offset target (~20 ms saved). Encode and display are the same on both paths. HTTP `/stream` still uses the 24 ms ExoPlayer offset.
+
+## Environment
+
+| Variable | Role |
+|----------|------|
+| `ORBISCREEN_UDP_MAX_DATAGRAM` | Upper bound of the PMTU search (clamped 576–65507, default 1472) |
+| `ORBISCREEN_UDP_DROP_ABOVE` | Pretend larger datagrams were lost (PMTU test hook) |
+| `ORBISCREEN_UDP_LOSS_PCT` | Randomly drop outgoing datagrams, 0–90 (loss test hook) |


### PR DESCRIPTION
Adds a second video path: H.264 Annex-B over UDP with per-client DPLPMTUD, plus KWin unique virtual outputs bound to Direct Touch.

### What does this PR do?

H.264 access units go over UDP on `signaling_port + 1` (`udp_port` on `/api/info`). Hello carries the session token; ping/pong measures RTT; IDR requests reuse the encoder force-key-unit path. Android prefers UDP and decodes with MediaCodec onto a Surface. HTTP `/stream` stays for the web client and as fallback (USB/AOA `127.0.0.1` cannot carry raw UDP).

Per-client DPLPMTUD probes upward from 1200 bytes. Video waits for a confirmed datagram size, then fragments to it. The stream menu shows send-to-assemble delay as `delay Nms`.

KWin creates `Virtual-ORBISCREEN`, then `Virtual-ORBISCREEN-{pid}` if that name is taken. Mouse, touchscreen, and tablet bind to the connector the stream actually accepted. After the last client leaves, the virtual output is parked.

Protocol details: [docs/UDP_TRANSPORT.md](docs/UDP_TRANSPORT.md).

### Why?

HTTP MPEG-TS + ExoPlayer targets a 24 ms live offset (8–48 ms). On a 2560×1600 VA-API Wi-Fi path (SM-T725), UDP send-to-assemble delay is 2–4 ms (typically 2–3 ms), about 10× less player/transport delay.

### How was it tested?

- [x] `cargo fmt --all`
- [x] `cargo test` on `orbiscreen-transport`, `orbiscreen-capture`, `orbiscreen-input`; daemon compiles
- [x] Android `assembleDebug` + unit tests
- [x] Live: KDE Plasma Wayland + Samsung Galaxy Tab S5e (SM-T725) on Wi-Fi. UDP PMTU 1472, devices bound to `Virtual-ORBISCREEN-{pid}`, menu shows `delay 2–4ms`. Packet-loss hooks (`ORBISCREEN_UDP_LOSS_PCT`) hold P-frames and request IDR.

### Checklist

- [x] No new warnings introduced.
- [x] File headers match Orbiscreen style.
- [x] `CHANGELOG.md` updated.