### PR TITLE
orbiscreen | fix: measure UDP PMTU without truncated ACKs or fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+
+### 🐛 Fixed
+- **UDP PMTU Measurement (`orbiscreen-transport`, Android)**:
+  - Android reused a `DatagramPacket` without resetting `length`, so probe ACKs could report the previous packet's size (often a 21-byte pong) and the search stalled or locked onto a too-small datagram. Reset the receive cap before every `receive`.
+  - Truncated ACKs reject the in-flight probe size. Local `EMSGSIZE` / `drop_above` rejects fail that size immediately instead of waiting for a timeout.
+
 ## [v0.25.0] - 2026-09-08
 
 ### 🖥 Linux Desktop GUI Control Center

--- a/clients/android/app/src/main/java/com/orbiscreen/android/player/UdpPlayer.kt
+++ b/clients/android/app/src/main/java/com/orbiscreen/android/player/UdpPlayer.kt
@@ -39,7 +39,7 @@ private const val TYPE_IDR: Byte = 6
 private const val TYPE_PROBE: Byte = 7
 private const val TYPE_PROBE_ACK: Byte = 8
 private const val TYPE_PMTU: Byte = 9
-private const val RECV_BUF: Int = 4096
+private const val RECV_BUF: Int = 65_507
 
 enum class HandshakeAction { Ack, Control, Ignore }
 
@@ -109,6 +109,7 @@ class UdpPlayer {
             var acked = false
             while (!acked && System.currentTimeMillis() < deadline) {
                 try {
+                    prepareReceive(pkt, buf)
                     sock.receive(pkt)
                     val data = buf.copyOf(pkt.length)
                     when (handshakeAction(data)) {
@@ -204,6 +205,7 @@ class UdpPlayer {
         val pkt = DatagramPacket(buf, buf.size)
         while (running) {
             try {
+                prepareReceive(pkt, buf)
                 socket?.receive(pkt) ?: break
                 handle(buf.copyOf(pkt.length))
             } catch (e: Exception) {
@@ -431,6 +433,10 @@ class UdpPlayer {
             }
         }
 
+        fun prepareReceive(pkt: DatagramPacket, buf: ByteArray) {
+            // length is both "bytes received" and "next receive cap".
+            pkt.length = buf.size
+        }
         fun encodeHello(token: String): ByteArray {
             val t = token.toByteArray(Charsets.UTF_8)
             return byteArrayOf('O'.code.toByte(), 'R'.code.toByte(), 'B'.code.toByte(), '1'.code.toByte(), TYPE_HELLO) + t

--- a/clients/android/app/src/test/java/com/orbiscreen/android/player/UdpPmtuTest.kt
+++ b/clients/android/app/src/test/java/com/orbiscreen/android/player/UdpPmtuTest.kt
@@ -4,6 +4,9 @@ package com.orbiscreen.android.player
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
 
 class UdpPmtuTest {
 
@@ -39,5 +42,27 @@ class UdpPmtuTest {
         UdpPlayer.putLe16(buf, 2, 1472)
         assertEquals(0x1234, UdpPlayer.le16(buf, 0))
         assertEquals(1472, UdpPlayer.le16(buf, 2))
+    }
+
+    @Test
+    fun reusedPacketReportsFullSizeAfterPrepareReceive() {
+        val server = DatagramSocket()
+        val client = DatagramSocket()
+        try {
+            val buf = ByteArray(2048)
+            val pkt = DatagramPacket(buf, buf.size)
+            val addr = InetAddress.getByName("127.0.0.1")
+            server.soTimeout = 2000
+            client.send(DatagramPacket(ByteArray(21), 21, addr, server.localPort))
+            server.receive(pkt)
+            assertEquals(21, pkt.length)
+            client.send(DatagramPacket(ByteArray(1400), 1400, addr, server.localPort))
+            UdpPlayer.prepareReceive(pkt, buf)
+            server.receive(pkt)
+            assertEquals(1400, pkt.length)
+        } finally {
+            server.close()
+            client.close()
+        }
     }
 }

--- a/crates/orbiscreen-transport/src/udp_stream.rs
+++ b/crates/orbiscreen-transport/src/udp_stream.rs
@@ -134,7 +134,10 @@ impl PmtuSearch {
             return;
         };
         if recv < probe {
+            // Receiver did not see the full datagram (truncation or a stale
+            // smaller packet). That size is not usable.
             self.raise(recv);
+            self.fail();
             return;
         }
         self.low = probe;
@@ -150,6 +153,10 @@ impl PmtuSearch {
         if self.attempts >= MAX_PROBE_ATTEMPTS {
             self.fail();
         }
+    }
+
+    pub fn on_unsendable(&mut self) {
+        self.fail();
     }
 
     fn fail(&mut self) {
@@ -436,34 +443,81 @@ fn should_lose(loss_pct: u8) -> bool {
     loss_pct > 0 && rand::rng().random_range(0u8..100) < loss_pct
 }
 
-async fn send_datagram(sock: &UdpSocket, buf: &[u8], addr: SocketAddr, limits: UdpLimits) -> bool {
-    if would_drop(buf.len(), limits.drop_above) || should_lose(limits.loss_pct) {
-        return false;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SendOutcome {
+    Sent,
+    TooBig,
+    Failed,
+}
+
+fn is_msg_too_big(err: &std::io::Error) -> bool {
+    err.raw_os_error() == Some(libc::EMSGSIZE)
+}
+
+async fn send_datagram(
+    sock: &UdpSocket,
+    buf: &[u8],
+    addr: SocketAddr,
+    limits: UdpLimits,
+) -> SendOutcome {
+    if would_drop(buf.len(), limits.drop_above) {
+        return SendOutcome::TooBig;
     }
-    if let Err(e) = sock.send_to(buf, addr).await {
-        debug!(%addr, "UDP send failed: {e}");
-        return false;
+    if should_lose(limits.loss_pct) {
+        return SendOutcome::Failed;
     }
-    true
+    match sock.send_to(buf, addr).await {
+        Ok(_) => SendOutcome::Sent,
+        Err(e) if is_msg_too_big(&e) => {
+            debug!(%addr, len = buf.len(), "UDP datagram too big: {e}");
+            SendOutcome::TooBig
+        }
+        Err(e) => {
+            debug!(%addr, "UDP send failed: {e}");
+            SendOutcome::Failed
+        }
+    }
 }
 
 async fn send_probe(sock: &UdpSocket, addr: SocketAddr, client: &mut UdpClient, limits: UdpLimits) {
-    let Some(size) = client.pmtu.current_probe() else {
-        return;
-    };
-    if client.probe_id == 0 {
-        client.probe_id = 1;
+    loop {
+        let Some(size) = client.pmtu.current_probe() else {
+            return;
+        };
+        if client.probe_id == 0 {
+            client.probe_id = 1;
+        }
+        let pkt = encode_probe(client.probe_id, size);
+        match send_datagram(sock, &pkt, addr, limits).await {
+            SendOutcome::Sent => {
+                client.probe_deadline = Some(Instant::now() + PROBE_TIMEOUT);
+                debug!(%addr, size, id = client.probe_id, "UDP PMTU probe");
+                return;
+            }
+            SendOutcome::TooBig => {
+                debug!(
+                    %addr,
+                    size,
+                    id = client.probe_id,
+                    "UDP PMTU probe rejected locally"
+                );
+                client.probe_deadline = None;
+                client.pmtu.on_unsendable();
+                bump_probe_id(client);
+            }
+            SendOutcome::Failed => {
+                client.probe_deadline = Some(Instant::now() + PROBE_TIMEOUT);
+                debug!(
+                    %addr,
+                    size,
+                    id = client.probe_id,
+                    sent = false,
+                    "UDP PMTU probe"
+                );
+                return;
+            }
+        }
     }
-    client.probe_deadline = Some(Instant::now() + PROBE_TIMEOUT);
-    let pkt = encode_probe(client.probe_id, size);
-    let sent = send_datagram(sock, &pkt, addr, limits).await;
-    debug!(
-        %addr,
-        size,
-        id = client.probe_id,
-        sent,
-        "UDP PMTU probe"
-    );
 }
 
 async fn announce_pmtu(
@@ -628,11 +682,12 @@ pub async fn run_udp_hub(
                         if client.pmtu.current_probe() != before {
                             bump_probe_id(client);
                         }
+                        if client.pmtu.current_probe().is_some() {
+                            send_probe(&sock, *addr, client, limits).await;
+                        }
                         if client.pmtu.is_complete() {
                             announce_pmtu(&sock, *addr, client, limits).await;
                             request_idr_sender(idr_tx.as_ref());
-                        } else if client.pmtu.current_probe().is_some() {
-                            send_probe(&sock, *addr, client, limits).await;
                         }
                     }
                 }
@@ -658,7 +713,7 @@ pub async fn run_udp_hub(
                 for (addr, payload) in targets {
                     let frames = fragment_video(seq, &pkt, sent_ns, payload);
                     for frame in &frames {
-                        if !send_datagram(&sock, frame, addr, limits).await {
+                        if send_datagram(&sock, frame, addr, limits).await != SendOutcome::Sent {
                             break;
                         }
                     }
@@ -702,10 +757,11 @@ async fn handle_incoming(buf: &[u8], addr: SocketAddr, ctx: &IncomingCtx<'_>) {
             }
             let _ = send_datagram(ctx.sock, &encode_hello_ack(), addr, ctx.limits).await;
             if joining {
+                if client.pmtu.current_probe().is_some() {
+                    send_probe(ctx.sock, addr, client, ctx.limits).await;
+                }
                 if client.pmtu.is_complete() {
                     announce_pmtu(ctx.sock, addr, client, ctx.limits).await;
-                } else {
-                    send_probe(ctx.sock, addr, client, ctx.limits).await;
                 }
             }
         }
@@ -728,24 +784,20 @@ async fn handle_incoming(buf: &[u8], addr: SocketAddr, ctx: &IncomingCtx<'_>) {
             let recv = recv as usize;
             match apply_probe_ack(client, id, recv) {
                 AckEffect::Ignored => {}
-                AckEffect::Completed => {
+                AckEffect::Completed | AckEffect::Continue => {
                     debug!(
                         %addr,
                         recv,
                         confirmed = client.pmtu.confirmed(),
                         "UDP PMTU ack"
                     );
-                    announce_pmtu(ctx.sock, addr, client, ctx.limits).await;
-                    request_idr_sender(ctx.idr_tx);
-                }
-                AckEffect::Continue => {
-                    debug!(
-                        %addr,
-                        recv,
-                        confirmed = client.pmtu.confirmed(),
-                        "UDP PMTU ack"
-                    );
-                    send_probe(ctx.sock, addr, client, ctx.limits).await;
+                    if client.pmtu.current_probe().is_some() {
+                        send_probe(ctx.sock, addr, client, ctx.limits).await;
+                    }
+                    if client.pmtu.is_complete() {
+                        announce_pmtu(ctx.sock, addr, client, ctx.limits).await;
+                        request_idr_sender(ctx.idr_tx);
+                    }
                 }
             }
         }
@@ -936,6 +988,33 @@ mod tests {
         assert_eq!(search.confirmed(), BASE_DATAGRAM);
         assert_eq!(search.video_payload(), BASE_DATAGRAM - VIDEO_HEADER_LEN);
         assert!(!search.is_complete());
+    }
+
+    #[test]
+    fn default_max_is_ipv4_ethernet_udp_payload() {
+        assert_eq!(DEFAULT_MAX_DATAGRAM, 1500 - 20 - 8);
+    }
+
+    #[test]
+    fn truncated_ack_rejects_probe_size() {
+        let mut search = PmtuSearch::from_min(DEFAULT_MAX_DATAGRAM);
+        let probe = search.current_probe().expect("armed");
+        let floor = search.confirmed();
+        search.on_ack(probe / 2);
+        assert_ne!(search.current_probe(), Some(probe));
+        assert_eq!(search.confirmed(), floor);
+    }
+
+    #[test]
+    fn unsendable_probe_narrows_search() {
+        let mut search = PmtuSearch::from_min(DEFAULT_MAX_DATAGRAM);
+        let probe = search.current_probe().expect("armed");
+        search.on_unsendable();
+        assert!(search.confirmed() < probe);
+        assert!(
+            search.is_complete() || search.current_probe().is_some_and(|next| next < probe),
+            "next probe should be smaller than the rejected size"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
### What does this PR do?

Stops UDP DPLPMTUD from locking onto a too-small datagram.

Android reused a `DatagramPacket` without resetting `length`, so a 21-byte pong left the next receive capped at 21 bytes. Probe ACKs then reported that stale size and the search stalled. Reset the receive cap before every `receive`, enlarge the Android receive buffer to a full UDP datagram, and reject a probe when the ACK is shorter than what was sent.

On the host, `EMSGSIZE` and `ORBISCREEN_UDP_DROP_ABOVE` now fail that probe size immediately instead of waiting for a timeout.

### Why?

A truncated or stale ACK made PMTU discovery sit on ~21 bytes (or another leftover size). Video then fragmented to that payload and the stream stalled or looked broken. Local rejects that already know a size cannot be sent should not wait 250 ms × 3 attempts.

See the `[Unreleased]` entry in `CHANGELOG.md`.

### How was it tested?

- [x] `cargo fmt --all`
- [x] `cargo clippy -p orbiscreen-transport --all-targets --locked -- -D warnings`
- [x] `cargo test -p orbiscreen-transport --locked` (27 lib tests + mpegts mux, including `truncated_ack_rejects_probe_size` and `unsendable_probe_narrows_search`)
- [ ] Android `UdpPmtuTest` (Gradle 8.9 cannot start on the local JDK 26.0.2)
- [ ] Manual smoke test on: not re-run after rebase

### Checklist

- [x] No new warnings introduced.
- [x] File headers match Orbiscreen style (`// Orbiscreen - <module> (GPL-3.0-or-later)` + GitHub URL).
- [x] `CHANGELOG.md` updated.